### PR TITLE
counters for events began and completed

### DIFF
--- a/include/SimCore/RootPersistencyManager.h
+++ b/include/SimCore/RootPersistencyManager.h
@@ -174,14 +174,8 @@ namespace ldmx {
 
         private:
 
-            /* 
-             * Description of the current run.  The description is persisted 
-             * in the run header. 
-             */ 
-            std::string description_{""};
-
-            /// Run number
-            int runNumber_{0}; 
+            /// Configuration parameters passed to Simulator
+            Parameters parameters_;
 
             /// Number of events started on this production run
             int eventsBegan_{-1};

--- a/include/SimCore/RootPersistencyManager.h
+++ b/include/SimCore/RootPersistencyManager.h
@@ -112,6 +112,23 @@ namespace ldmx {
              * @param event Event buffer for the current event. 
              */
             void setCurrentEvent(Event* event) { event_ = event; }
+            /**
+             * Set the number of events began and completed.
+             *
+             * These two numbers may or may not be equal
+             * depending on if the simulation ran with any filters
+             * that would abort events early.
+             *
+             * These numbers are helpful for evaluating filtering
+             * performance, so we put them both in the RunHeader.
+             *
+             * @param[in] began number of events that were started
+             * @param[in] completed number of events that were completed without an abort signal
+             */
+            void setNumEvents(int began, int completed) {
+                eventsBegan_ = began;
+                eventsCompleted_ = completed;
+            }
 
         public:
 
@@ -165,6 +182,12 @@ namespace ldmx {
 
             /// Run number
             int runNumber_{0}; 
+
+            /// Number of events started on this production run
+            int eventsBegan_{-1};
+
+            /// Number of events completed without being aborted (due to filters)
+            int eventsCompleted_{-1};
 
             /// The output file. 
             EventFile &file_;

--- a/include/SimCore/Simulator.h
+++ b/include/SimCore/Simulator.h
@@ -156,6 +156,12 @@ namespace ldmx {
             ///     This is because Simulator already runs them.
             static const std::vector< std::string > invalidCommands_;
 
+            /// Number of events started
+            int numEventsBegan_{0};
+
+            /// Number of events completed
+            int numEventsCompleted_{0};
+
             /*********************************************************
              * Python Configuration Parameters
              *********************************************************/

--- a/src/RootPersistencyManager.cxx
+++ b/src/RootPersistencyManager.cxx
@@ -39,9 +39,8 @@ namespace ldmx {
         G4PersistencyCenter::GetPersistencyCenter()->RegisterPersistencyManager(this);
         G4PersistencyCenter::GetPersistencyCenter()->SetPersistencyManager(this, "RootPersistencyManager");
 
-        // Set the description 
-        description_ = parameters.getParameter< std::string >("description"); 
-        runNumber_   = parameters.getParameter< int >("runNumber");
+        // Set the parameters, used laster when printing run header
+        parameters_ = parameters;
         
         ecalHitIO_.setEnableHitContribs(parameters.getParameter< bool >("enableHitContribs")); 
         ecalHitIO_.setCompressHitContribs(parameters.getParameter< bool >("compressHitContribs"));
@@ -70,12 +69,31 @@ namespace ldmx {
             = static_cast<RunManager*>(RunManager::GetRunManager())->getDetectorConstruction();
 
         // Create the run header.
-        RunHeader runHeader( runNumber_ , detector->getDetectorHeader()->getName(), description_ );
+        RunHeader runHeader( 
+                parameters_.getParameter<int>("runNumber"),
+                detector->getDetectorHeader()->getName(), 
+                parameters_.getParameter<std::string>("description")
+                );
+
 
         // Set parameter value with number of events processed.
         runHeader.setIntParameter("Event Count", eventsCompleted_ );
         runHeader.setIntParameter("Events Began" , eventsBegan_ );
-        
+
+        runHeader.setIntParameter("Save ECal Hit Contribs" , parameters_.getParameter<bool>("enableHitContribs"));
+        runHeader.setIntParameter("Compress ECal Hit Contribs" , parameters_.getParameter<bool>("compressHitContribs"));
+
+        if ( parameters_.getParameter<bool>("biasing_enabled") ) {
+            runHeader.setStringParameter("Biasing Process"  , parameters_.getParameter<std::string>("biasing_process"));
+            runHeader.setStringParameter("Biasing Volume"   , parameters_.getParameter<std::string>("biasing_volume"));
+            runHeader.setStringParameter("Biasing Particle" , parameters_.getParameter<std::string>("biasing_particle"));
+            runHeader.setIntParameter(   "Biasing All"      , parameters_.getParameter<bool>(       "biasing_all" ));
+            runHeader.setIntParameter(   "Biasing Incident" , parameters_.getParameter<bool>(       "biasing_incident" ));
+            runHeader.setIntParameter(   "Biasing Disable EM",parameters_.getParameter<bool>(       "biasing_disableEMBiasing" ));
+            runHeader.setIntParameter(   "Biasing Factor"   , parameters_.getParameter<int>(        "biasing_factor" ));
+            runHeader.setFloatParameter( "Biasing Threshold", parameters_.getParameter<double>(     "biasing_threshold" ));
+        }
+
         // Set a string parameter with the Geant4 SHA-1.
         G4String g4Version{G4RunManagerKernel::GetRunManagerKernel()->GetVersionString()};
         runHeader.setStringParameter("Geant4 revision", g4Version); 

--- a/src/RootPersistencyManager.cxx
+++ b/src/RootPersistencyManager.cxx
@@ -73,8 +73,9 @@ namespace ldmx {
         RunHeader runHeader( runNumber_ , detector->getDetectorHeader()->getName(), description_ );
 
         // Set parameter value with number of events processed.
-        runHeader.setIntParameter("Event count", aRun->GetNumberOfEvent());
-
+        runHeader.setIntParameter("Event Count", eventsCompleted_ );
+        runHeader.setIntParameter("Events Began" , eventsBegan_ );
+        
         // Set a string parameter with the Geant4 SHA-1.
         G4String g4Version{G4RunManagerKernel::GetRunManagerKernel()->GetVersionString()};
         runHeader.setStringParameter("Geant4 revision", g4Version); 


### PR DESCRIPTION
`Simulator` counts the number of events that we start and the number that complete (don't get aborted). The internal Geant4 counters depend on running the entire event loop through Geant4, so we need to have our own counters to make sure it happens the way we want.