### PR TITLE
remove unsafe process calls in Simulator

### DIFF
--- a/include/SimCore/RootPersistencyManager.h
+++ b/include/SimCore/RootPersistencyManager.h
@@ -60,9 +60,11 @@ namespace ldmx {
             /**
              * Class constructor.
              *
-             * @param eventFile 
+             * @param eventFile file to put output events into
+             * @param parameters configuration parameters from Simulator
+             * @param runNumber current run identifer from Process
              */
-            RootPersistencyManager(EventFile &file, Parameters& parameters);
+            RootPersistencyManager(EventFile &file, Parameters& parameters, const int& runNumber);
 
             /// Destructor 
             virtual ~RootPersistencyManager() { }
@@ -170,6 +172,9 @@ namespace ldmx {
 
             /// Configuration parameters passed to Simulator
             Parameters parameters_;
+
+            /// Run Number, given to us by Simulator from Process
+            int run_;
 
             /// Number of events started on this production run
             int eventsBegan_{-1};

--- a/python/simulator.py
+++ b/python/simulator.py
@@ -31,8 +31,6 @@ class simulator(Producer):
         Full path to detector description gdml (suggested to use setDetector)
     validate_detector : bool, optional
         Should we have Geant4 validate that the gdml is correctly formatted?
-    runNumber : int
-        Identifier for this run
     description : str
         Describe this run in a human-readable way
     scoringPlanes : str, optional
@@ -92,7 +90,6 @@ class simulator(Producer):
         # Required Parameters
         self.generators = [ ]
         self.detector = ''
-        self.runNumber = -1
         self.description = ''
 
         #######################################################################

--- a/src/RootPersistencyManager.cxx
+++ b/src/RootPersistencyManager.cxx
@@ -33,7 +33,7 @@
 
 namespace ldmx {
 
-    RootPersistencyManager::RootPersistencyManager(EventFile &file, Parameters& parameters) :
+    RootPersistencyManager::RootPersistencyManager(EventFile &file, Parameters& parameters, const int& runNumber) :
         G4PersistencyManager(G4PersistencyCenter::GetPersistencyCenter(), "RootPersistencyManager"),
         file_(file) {
 
@@ -47,6 +47,7 @@ namespace ldmx {
         ecalHitIO_.setEnableHitContribs(parameters.getParameter< bool >("enableHitContribs")); 
         ecalHitIO_.setCompressHitContribs(parameters.getParameter< bool >("compressHitContribs"));
 
+        run_ = runNumber;
     }
 
     G4bool RootPersistencyManager::Store(const G4Event* anEvent) {
@@ -72,7 +73,7 @@ namespace ldmx {
 
         // Create the run header.
         RunHeader runHeader( 
-                parameters_.getParameter<int>("runNumber"),
+                run_,
                 detector->getDetectorHeader()->getName(), 
                 parameters_.getParameter<std::string>("description")
                 );

--- a/src/Simulator.cxx
+++ b/src/Simulator.cxx
@@ -56,10 +56,6 @@ namespace ldmx {
         // parameters used to configure the simulation
         parameters_ = parameters; 
         
-        // Set the run number. If not specified, the run number is set to 0. 
-        int runNumber = parameters_.getParameter< int >( "runNumber" );
-        process_.setRunNumber( runNumber );
-
         // Set the verbosity level.  The default level  is 0.
         verbosity_ = parameters_.getParameter< int >("verbosity");
 
@@ -122,7 +118,7 @@ namespace ldmx {
 
     void Simulator::onFileOpen(EventFile &file) {
         // Initialize persistency manager and connect it to the current EventFile
-        persistencyManager_ = std::make_unique<RootPersistencyManager>(file, parameters_); 
+        persistencyManager_ = std::make_unique<RootPersistencyManager>(file, parameters_, this->getRunNumber()); 
         persistencyManager_->Initialize(); 
     }
 
@@ -144,7 +140,7 @@ namespace ldmx {
             this->abortEvent();  //get out of processors loop
         }
         
-        if ( process_.getLogFrequency() > 0 and event.getEventHeader().getEventNumber() % process_.getLogFrequency() == 0 ) {
+        if ( this->getLogFrequency() > 0 and event.getEventHeader().getEventNumber() % this->getLogFrequency() == 0 ) {
             //print according to log frequency and verbosity
             if ( verbosity_ > 1 ) std::cout << "[ Simulator ] : Printing event contents:" << std::endl;
             event.Print( verbosity_ );


### PR DESCRIPTION
This allows for us to make the `Process` reference in the `EventProcessor` base class private.

I've added a few accessors in the Framework module in order to get this to work.

**One Big Change**: The run number is set in `Process` instead of `Simulator`, so instead of
```python
mySim.runNumber = 5
```
You should do
```python
p.run = 5
```

Merging this in will **not compile** if the [corresponding changes to Framework](https://github.com/LDMX-Software/Framework/pull/7) aren't merged in as well.