### PR TITLE
Iss873 - Pass ecal hex readout parameters from python

### DIFF
--- a/include/SimCore/AuxInfoReader.h
+++ b/include/SimCore/AuxInfoReader.h
@@ -12,6 +12,7 @@
 
 // LDMX
 #include "DetDescr/DetectorHeader.h"
+#include "Framework/Parameters.h"
 
 namespace ldmx {
 
@@ -33,8 +34,9 @@ namespace ldmx {
             /**
              * Class constructor.
              * @param parser The GDML parser.
+             * @param ps configuration parameters
              */
-            AuxInfoReader(G4GDMLParser* parser);
+            AuxInfoReader(G4GDMLParser* parser, Parameters ps);
 
             /**
              * Class destructor.
@@ -112,6 +114,9 @@ namespace ldmx {
              * Detector header with name and version.
              */
             ldmx::DetectorHeader* detectorHeader_ {nullptr};
+
+            /// Configuration parameters
+            Parameters parameters_;
     };
 
 }

--- a/include/SimCore/EcalHitIO.h
+++ b/include/SimCore/EcalHitIO.h
@@ -52,64 +52,23 @@ namespace ldmx {
             /**
              * Class constructor.
              */
-            EcalHitIO() { 
-        
-                // These are the v12 parameters
-                //  all distances in mm
-                double moduleRadius = 85.0; //same as default
-                int    numCellsWide = 23; //same as default
-                double moduleGap = 1.0;
-                double ecalFrontZ = 220;
-                std::vector<double> ecalSensLayersZ = {
-                     7.850,
-                    13.300,
-                    26.400,
-                    33.500,
-                    47.950,
-                    56.550,
-                    72.250,
-                    81.350,
-                    97.050,
-                    106.150,
-                    121.850,
-                    130.950,
-                    146.650,
-                    155.750,
-                    171.450,
-                    180.550,
-                    196.250,
-                    205.350,
-                    221.050,
-                    230.150,
-                    245.850,
-                    254.950,
-                    270.650,
-                    279.750,
-                    298.950,
-                    311.550,
-                    330.750,
-                    343.350,
-                    362.550,
-                    375.150,
-                    394.350,
-                    406.950,
-                    426.150,
-                    438.750
-                };
-        
-                hexReadout_ = std::make_unique<EcalHexReadout>(
-                        moduleRadius,
-                        moduleGap,
-                        numCellsWide,
-                        ecalSensLayersZ,
-                        ecalFrontZ
-                        );
-            }
+            EcalHitIO() { }
 
             /**
              * Class destructor.
              */
             ~EcalHitIO() { }
+
+            /**
+             * Configure the EcalHitIO using the passed parameters
+             */
+            void configure(const Parameters& ps) {
+                enableHitContribs_   = ps.getParameter<bool>("enableHitContribs");
+                compressHitContribs_ = ps.getParameter<bool>("compressHitContribs");
+                auto hexReadout{ps.getParameter<Parameters>("ecalHexReadout")};
+                hexReadout_ = std::make_unique<EcalHexReadout>(hexReadout);
+            }
+
 
             /**
              * Write out a Geant4 hits collection to the provided ROOT array.

--- a/include/SimCore/EcalSD.h
+++ b/include/SimCore/EcalSD.h
@@ -41,6 +41,14 @@ namespace ldmx {
             virtual ~EcalSD();
 
             /**
+             * Configure this sensitive detector using the passed parameters
+             */
+            void configure(const Parameters& ps) {
+                auto hexReadout{ps.getParameter<Parameters>("ecalHexReadout")};
+                hitMap_ = std::make_unique<EcalHexReadout>(hexReadout);
+            }
+
+            /**
              * Process steps to create hits.
              * @param aStep The step information.
              * @param ROhist The readout history.

--- a/include/SimCore/RootPersistencyManager.h
+++ b/include/SimCore/RootPersistencyManager.h
@@ -114,6 +114,7 @@ namespace ldmx {
              * @param event Event buffer for the current event. 
              */
             void setCurrentEvent(Event* event) { event_ = event; }
+
             /**
              * Set the number of events began and completed.
              *

--- a/python/simulator.py
+++ b/python/simulator.py
@@ -31,6 +31,8 @@ class simulator(Producer):
         Full path to detector description gdml (suggested to use setDetector)
     validate_detector : bool, optional
         Should we have Geant4 validate that the gdml is correctly formatted?
+    ecalHexReadout : EcalHexReadout
+        Configuration for how to use EcalHexReadout class
     description : str
         Describe this run in a human-readable way
     scoringPlanes : str, optional
@@ -94,6 +96,8 @@ class simulator(Producer):
 
         #######################################################################
         # Optional Parameters (with helpful defaults)
+        from LDMX.DetDescr import EcalHexReadout
+        self.ecalHexReadout = EcalHexReadout.EcalHexReadout()
         self.scoringPlanes = ''
         self.randomSeeds = [ ] 
         self.beamSpotSmear = [ ]

--- a/src/AuxInfoReader.cxx
+++ b/src/AuxInfoReader.cxx
@@ -31,8 +31,8 @@ using std::string;
 
 namespace ldmx {
 
-    AuxInfoReader::AuxInfoReader(G4GDMLParser* theParser) :
-            parser_(theParser), eval_(new G4GDMLEvaluator) {
+    AuxInfoReader::AuxInfoReader(G4GDMLParser* theParser, Parameters ps) :
+            parser_(theParser), eval_(new G4GDMLEvaluator), parameters_(ps) {
     }
 
     AuxInfoReader::~AuxInfoReader() {
@@ -118,6 +118,7 @@ namespace ldmx {
             sd = new TrackerSD(theSensDetName, hcName, subdetID);
         } else if (sdType == "EcalSD") {
             sd = new EcalSD(theSensDetName, hcName, subdetID);
+            dynamic_cast<EcalSD*>(sd)->configure(parameters_);
         } else if (sdType == "HcalSD") {
             sd = new HcalSD(theSensDetName, hcName, subdetID);
         } else if (sdType == "ScoringPlaneSD") { 

--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -8,7 +8,7 @@
 namespace ldmx {
 
     DetectorConstruction::DetectorConstruction(G4GDMLParser* theParser, Parameters& parameters) :
-            parser_(theParser), auxInfoReader_(new AuxInfoReader(theParser)) {
+            parser_(theParser), auxInfoReader_(new AuxInfoReader(theParser, parameters)) {
                 parameters_ = parameters; 
     }
 

--- a/src/EcalSD.cxx
+++ b/src/EcalSD.cxx
@@ -17,10 +17,6 @@ namespace ldmx {
 
     EcalSD::EcalSD(G4String name, G4String theCollectionName, int subDetID) :
             CalorimeterSD(name, theCollectionName) {
-
-        detID_ = new EcalDetectorID(); 
-        detID_->setFieldValue("subdet", subDetID);
-
     }
 
     EcalSD::~EcalSD() {

--- a/src/EcalSD.cxx
+++ b/src/EcalSD.cxx
@@ -18,56 +18,9 @@ namespace ldmx {
     EcalSD::EcalSD(G4String name, G4String theCollectionName, int subDetID) :
             CalorimeterSD(name, theCollectionName) {
 
-        // These are the v12 parameters
-        //  all distances in mm
-        double moduleRadius = 85.0; //same as default
-        int    numCellsWide = 23; //same as default
-        double moduleGap = 1.5;
-        double ecalFrontZ = 220;
-        std::vector<double> ecalSensLayersZ = {
-             7.850,
-            13.300,
-            26.400,
-            33.500,
-            47.950,
-            56.550,
-            72.250,
-            81.350,
-            97.050,
-            106.150,
-            121.850,
-            130.950,
-            146.650,
-            155.750,
-            171.450,
-            180.550,
-            196.250,
-            205.350,
-            221.050,
-            230.150,
-            245.850,
-            254.950,
-            270.650,
-            279.750,
-            298.950,
-            311.550,
-            330.750,
-            343.350,
-            362.550,
-            375.150,
-            394.350,
-            406.950,
-            426.150,
-            438.750
-        };
+        detID_ = new EcalDetectorID(); 
+        detID_->setFieldValue("subdet", subDetID);
 
-        hitMap_ = std::make_unique<EcalHexReadout>(
-                moduleRadius,
-                moduleGap,
-                numCellsWide,
-                ecalSensLayersZ,
-                ecalFrontZ
-                );
     }
 
     EcalSD::~EcalSD() {
@@ -113,7 +66,7 @@ namespace ldmx {
         int module_position = cpynum%7;
 
         EcalID partialId = hitMap_->getCellModuleID(hitPosition[0], hitPosition[1]);
-	EcalID id(layerNumber, module_position, partialId.cell());
+	    EcalID id(layerNumber, module_position, partialId.cell());
         hit->setID(id.raw());
 
         // Set the track ID on the hit.
@@ -123,7 +76,7 @@ namespace ldmx {
         hit->setPdgCode(aStep->GetTrack()->GetParticleDefinition()->GetPDGEncoding());
 
         if (this->verboseLevel > 2) {
-	  G4cout << "Created new SimCalorimeterHit in detector " << this->GetName() << " with subdet ID " << id << " ...";
+	        G4cout << "Created new SimCalorimeterHit in detector " << this->GetName() << " with subdet ID " << id << " ...";
             hit->Print();
             G4cout << G4endl;
         }

--- a/src/ParallelWorld.cxx
+++ b/src/ParallelWorld.cxx
@@ -1,9 +1,11 @@
 
 #include "SimCore/ParallelWorld.h"
 
+#include "Framework/Parameters.h"
+
 ldmx::ParallelWorld::ParallelWorld(G4GDMLParser* parser, G4String worldName) 
     : G4VUserParallelWorld(worldName), parser_(parser), 
-      auxInfoReader_(new AuxInfoReader(parser)) {
+      auxInfoReader_(new AuxInfoReader(parser,Parameters())) {
 }
 
 ldmx::ParallelWorld::~ParallelWorld() {

--- a/src/RootPersistencyManager.cxx
+++ b/src/RootPersistencyManager.cxx
@@ -44,8 +44,7 @@ namespace ldmx {
         // Set the parameters, used laster when printing run header
         parameters_ = parameters;
         
-        ecalHitIO_.setEnableHitContribs(parameters.getParameter< bool >("enableHitContribs")); 
-        ecalHitIO_.setCompressHitContribs(parameters.getParameter< bool >("compressHitContribs"));
+        ecalHitIO_.configure( parameters_ );
 
         run_ = runNumber;
     }


### PR DESCRIPTION
Depends on PR #22 in this repo and the DetDescr changes in ldmx-sw.

This allows us to configure the ecal hex readout class from the python and pass this configuration to the ecal hex readout objects used in EcalSD and EcalHitIO during the simulation.