### PR TITLE
Enable container running again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,14 @@ endif()
 # Configure Geant4
 setup_geant4_target()
 
+# Search and configure ROOT
+find_package(ROOT CONFIG REQUIRED)
+
 # Setup the library 
 setup_library(name SimCore 
-              dependencies Geant4::Interface DARK::Framework DARK::DetDescr
+              dependencies Geant4::Interface ROOT::Physics DARK::Framework DARK::DetDescr
               python_install_path ${PYTHON_INSTALL_PREFIX}
+              python_root_module_name LDMX
 )
 
 # Set some target properties

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(ROOT CONFIG REQUIRED)
 setup_library(name SimCore 
               dependencies Geant4::Interface ROOT::Physics DARK::Framework DARK::DetDescr
               python_install_path ${PYTHON_INSTALL_PREFIX}
-              python_root_module_name LDMX
 )
 
 # Set some target properties

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,9 @@ find_package(ROOT CONFIG REQUIRED)
 
 # Setup the library 
 setup_library(name SimCore 
-              dependencies Geant4::Interface ROOT::Physics DARK::Framework DARK::DetDescr
+              dependencies Geant4::Interface 
+                           ROOT::Physics 
+                           DARK::Framework DARK::DetDescr
               python_install_path ${PYTHON_INSTALL_PREFIX}
 )
 

--- a/python/simulator.py
+++ b/python/simulator.py
@@ -84,7 +84,7 @@ class simulator(Producer):
     """
 
     def __init__(self, instance_name ) :
-        super().__init__( instance_name , "ldmx::Simulator" )
+        super().__init__( instance_name , "ldmx::Simulator" , "SimCore" )
 
         #######################################################################
         # Required Parameters
@@ -123,11 +123,6 @@ class simulator(Producer):
         self.darkbrem_madgraphfilepath = '' #required if want to use dark brem
         self.darkbrem_method = 0
         self.darkbrem_globalxsecfactor = 1.
-
-        # add necessary library to the list to load
-        #   requires a process object to have been defined
-        from LDMX.SimCore import include
-        include.library()
 
     def setDetector(self, det_name , include_scoring_planes = False ) :
         """Set the detector description with the option to include the scoring planes

--- a/test/basic.py
+++ b/test/basic.py
@@ -1,0 +1,23 @@
+from LDMX.Framework import ldmxcfg
+# create my process object
+p = ldmxcfg.Process( "test" )
+# how many events to process?
+p.maxEvents = 10
+# we want to see every event
+p.logFrequency = 1
+p.termLogLevel = 0
+# we also only have an output file
+p.outputFiles = [ "justSim_" + str(p.maxEvents) + "_events.root" ]
+from LDMX.SimCore import simulator as sim
+mySim = sim.simulator( "mySim" )
+mySim.setDetector( 'ldmx-det-v12' )
+# Set a run number
+mySim.runNumber = 9001
+# Get a pre-written generator
+from LDMX.SimCore import generators as gen
+mySim.generators.append( gen.single_4gev_e_upstream_tagger() )
+# add your configured simulation to the sequence
+mySim.description = 'Basic test Simulation'
+mySim.randomSeeds = [ 1 , 2 ]
+
+p.sequence.append( mySim )


### PR DESCRIPTION
- Remove need for include.py from simulator
- Add root as explicit dependency for the ROOT::Physics libraries
- Add a basic test configuration to make sure the simplest simulation can run