### PR TITLE
Shift primary vertices so that t=0 corresponds to z=0

### DIFF
--- a/include/SimCore/PrimaryGeneratorAction.h
+++ b/include/SimCore/PrimaryGeneratorAction.h
@@ -107,6 +107,14 @@ namespace ldmx {
             /** Extent of the beamspot in y. */
             double beamspotZSize_{0.};   
 
+            /**
+             * Should we time-shift so that the primary vertices arrive (or originate)
+             * at t=0ns at z=0mm?
+             *
+             * @note This should remain true unless the user knows what they are doing!
+             */
+            bool time_shift_primaries_{true};
+
     };  // PrimaryGeneratorAction
 
 } // ldmx

--- a/python/simulator.py
+++ b/python/simulator.py
@@ -37,6 +37,8 @@ class simulator(ldmxcfg.Producer):
         Full path to the scoring planes gdml (suggested to use setDetector)
     beamSpotSmear : list of float, optional
         2 (x,y) or 3 (x,y,z) widths to smear ALL primary vertices by [mm]
+    time_shift_primaries : bool
+        Should we shift the times of primaries so that z=0mm corresponds to t=0ns? 
     enableHitContribs : bool, optional
         Should the simulation save contributions to Ecal sim hits?
     compressHitContribs : bool, optional
@@ -99,6 +101,7 @@ class simulator(ldmxcfg.Producer):
         # Optional Parameters (with helpful defaults)
         self.scoringPlanes = ''
         self.beamSpotSmear = [ ]
+        self.time_shift_primaries = True
         self.enableHitContribs   = True
         self.compressHitContribs = True
         self.preInitCommands = [ ]

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -46,6 +46,8 @@ namespace ldmx {
             beamspotZSize_ = beamSpot[2];
         }
 
+        time_shift_primaries_ = parameters.getParameter<bool>("time_shift_primaries");
+
         auto generators{parameters_.getParameter< std::vector< Parameters > >("generators",{})};
         if ( generators.empty() ) {
             EXCEPTION_RAISE(
@@ -78,6 +80,15 @@ namespace ldmx {
         if (event->GetNumberOfPrimaryVertex() > 0) {
             setUserPrimaryInfo(event);
             if (useBeamspot_) smearingBeamspot(event);
+            if (time_shift_primaries_) {
+              // shift the time so that a light-speed particle
+              // arrives at the target at 0ns
+              int nPV = event->GetNumberOfPrimaryVertex();
+              for (int iPV = 0; iPV < nPV; ++iPV) {
+                G4PrimaryVertex *pv = event->GetPrimaryVertex(iPV);
+                pv->SetT0( pv->GetT0() + pv->GetZ0()/299.702547 );
+              }
+            }
         } else {
             EXCEPTION_RAISE(
                     "NoPrimaries",


### PR DESCRIPTION
Now that the ECal digi pipeline is using the time of the pulse for some calculations, we need to ensure uniformity.

This shifting can be turned off if the user wishes, but it is on by default.