### PR TITLE
Don't construct dark brem process until we are enabling it

### DIFF
--- a/include/SimCore/DarkBrem/APrimePhysics.h
+++ b/include/SimCore/DarkBrem/APrimePhysics.h
@@ -16,6 +16,13 @@
 #include "SimCore/DarkBrem/G4eDarkBremsstrahlung.h"
 
 namespace simcore {
+
+/**
+ * @namespace darkbrem
+ *
+ * In here we contain all of our framework for simulating
+ * the dark bremsstrahlung process in Geant4.
+ */
 namespace darkbrem {
 
 /**
@@ -92,8 +99,14 @@ class APrimePhysics : public G4VPhysicsConstructor {
   /// is dark brem enabled for this run?
   bool enable_;
 
-  /// the dark brem process itself
-  G4eDarkBremsstrahlung db_process_;
+  /**
+   * Dark brem parameters to pass to the process (if enabled)
+   *
+   * @note This can't be a reference because we pass it to
+   * the process _after_ the configuration step from our POV
+   * is done. Thus we need our own copy that won't be destroyed.
+   */
+  framework::config::Parameters parameters_;
 };
 
 }  // namespace darkbrem

--- a/include/SimCore/DarkBrem/APrimePhysics.h
+++ b/include/SimCore/DarkBrem/APrimePhysics.h
@@ -20,6 +20,8 @@ namespace simcore {
 /**
  * @namespace darkbrem
  *
+ * Extending Geant4 to dark bremsstrahlung
+ *
  * In here we contain all of our framework for simulating
  * the dark bremsstrahlung process in Geant4.
  */

--- a/python/dark_brem.py
+++ b/python/dark_brem.py
@@ -72,16 +72,23 @@ class DarkBrem:
         self.cache_xsec         = True
         self.model              = DarkBremModel('UNDEFINED')
 
-    def activate(self, ap_mass, model) :
-        """Activate the dark brem process with the input A' mass [MeV] and dark brem model"""
+    def activate(self, ap_mass, model = None) :
+        """Activate the dark brem process with the input A' mass [MeV] and dark brem model
 
-        self.enable  = True
+        If no dark brem model is given, we do not activate the process
+        and only define the A' mass. This allows for some backwards
+        compatibility by allowing users to use the LHEPrimaryGenerator
+        with A' particles.
+        """
+
         self.ap_mass = ap_mass
 
-        if not isinstance(model,DarkBremModel) :
-            raise Exception('Dark brem process needs to be configured with an associated model.')
-
-        self.model = model
+        if model is not None :
+            if not isinstance(model,DarkBremModel) :
+                raise Exception('Dark brem process needs to be configured with an associated DarkBremModel.')
+    
+            self.enable = True
+            self.model  = model
 
     def __str__(self): 
         """Stringify the DarkBrem configuration

--- a/src/SimCore/DarkBrem/APrimePhysics.cxx
+++ b/src/SimCore/DarkBrem/APrimePhysics.cxx
@@ -20,9 +20,10 @@ namespace darkbrem {
 const std::string APrimePhysics::NAME = "APrime";
 
 APrimePhysics::APrimePhysics(const framework::config::Parameters &params)
-    : G4VPhysicsConstructor(APrimePhysics::NAME), db_process_(params) {
-      ap_mass_ = params.getParameter<double>("ap_mass")*MeV;
-      enable_ = params.getParameter<bool>("enable");
+    : G4VPhysicsConstructor(APrimePhysics::NAME),
+      parameters_{params} {
+      ap_mass_ = parameters_.getParameter<double>("ap_mass")*MeV;
+      enable_ = parameters_.getParameter<bool>("enable");
 }
 
 void APrimePhysics::ConstructParticle() {
@@ -55,7 +56,7 @@ void APrimePhysics::ConstructProcess() {
      * 1000 which seems to be safely above all the internal/default processes.
      */
     G4Electron::ElectronDefinition()->GetProcessManager()
-      ->AddDiscreteProcess(&db_process_);
+      ->AddDiscreteProcess(new G4eDarkBremsstrahlung(parameters_));
   }
 }
 

--- a/src/SimCore/DarkBrem/APrimePhysics.cxx
+++ b/src/SimCore/DarkBrem/APrimePhysics.cxx
@@ -22,8 +22,8 @@ const std::string APrimePhysics::NAME = "APrime";
 APrimePhysics::APrimePhysics(const framework::config::Parameters &params)
     : G4VPhysicsConstructor(APrimePhysics::NAME),
       parameters_{params} {
-      ap_mass_ = parameters_.getParameter<double>("ap_mass")*MeV;
-      enable_ = parameters_.getParameter<bool>("enable");
+      ap_mass_ = parameters_.getParameter<double>("ap_mass",0.)*MeV;
+      enable_ = parameters_.getParameter<bool>("enable",false);
 }
 
 void APrimePhysics::ConstructParticle() {


### PR DESCRIPTION
This is necessary to allow simulations to be configured _without_ a dark brem model.

@mrsolt and @Martinbmeier pointed out this error to me. It can be fixed on the configuration script level by defining a model and then de-activating the dark brem process.
```python
from LDMX.SimCore import dark_brem
from LDMX.SimCore import makePath
db_model = dark_brem.VertexLibraryModel( makePath.makeLHEPath(1000.) )
sim.dark_brem.activate( 1000. , db_model )
sim.dark_brem.enable = False
```

This PR shifts when we construct the dark brem process so that it is only constructed when the process has been enabled.