### PR TITLE
Iss24 - Write program to access Geant4-native visualization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,3 +115,8 @@ if(INSTALL_EXAMPLE_DB_LIBRARIES)
 endif()
 
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/SimCore)
+
+# add visualization executable
+add_executable(g4-vis ${PROJECT_SOURCE_DIR}/src/SimCore/g4_vis.cxx)
+target_link_libraries(g4-vis PRIVATE Geant4::Interface SimCore::SimCore)
+install(TARGETS g4-vis DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ You will likely want to change the point of view from which you are looking at t
 detector. The [camera working commands](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Visualization/commandcontrol.html#basic-camera-workings-vis-viewer-commands)
 is what Geant4 calls these.
 
+Here is a quick reference table for moving the camerage around.
+
+Command | Description
+--------|------------
+`/vis/viewer/pan x y units` | Move camera a certain amount left/right (x) and up/down (y) a given amount of units
+`/vis/viewer/set/viewpointThetaPhi theta phi deg|rad` | Rotate the camerage to the input direction vector in degrees or radians
+`/vis/viewer/zoom scale` | Zoom towards the center of the image by the input factor
+
+#### Limitations
+The class we use to read-in our GDML and construct the Geant4 detector model
+makes a large number of assumptions about how the GDML is structured.
+With this in mind, it is best to use the central `detector.gdml` file as 
+the "entrypoint" and comment out the different parts of the detector
+you don't want to see.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # SimCore
+
+This repository is focused on integrating the 
+[Geant4 simulation framework](https://github.com/LDMX-Software/geant4) 
+into another [event processing framework](https://github.com/LDMX-Software/Framework).
+
+This is centered upon a processor that does the necessary
+configuring, processing, and persisting steps tied with Geant4.
+
+## Detector Visualization
+
+The event processing framework that actually runs this simulation
+is not well designed for running a visualization. For this reason,
+a small program has been written that loads the input detector
+description GDML file and launches an interactive Geant4 terminal.
+
+The simulation is not well configured, so this interactive terminal
+**should only be used for visualization**.
+
+#### Common Geant4 Vis Commands
+More detailed documentation for these commands are given in the 
+[Geant4 Book for App Developers](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Visualization/commandcontrol.html#scene-scene-handler-and-viewer)
+
+In general, you can get started quickly by running the following
+commands in the given sequence after the Geant4 interactive terminal
+is launched.
+
+```
+/vis/open OGL
+/vis/drawVolume
+/vis/viewer/refresh
+```
+
+You will likely want to change the point of view from which you are looking at the
+detector. The [camera working commands](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Visualization/commandcontrol.html#basic-camera-workings-vis-viewer-commands)
+is what Geant4 calls these.
+
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here is a quick reference table for moving the camerage around.
 Command | Description
 --------|------------
 `/vis/viewer/pan x y units` | Move camera a certain amount left/right (x) and up/down (y) a given amount of units
-`/vis/viewer/set/viewpointThetaPhi theta phi deg|rad` | Rotate the camerage to the input direction vector in degrees or radians
+`/vis/viewer/set/viewpointThetaPhi theta phi units` | Rotate the camerage to the input direction vector in degrees or radians
 `/vis/viewer/zoom scale` | Zoom towards the center of the image by the input factor
 
 #### Limitations

--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ makes a large number of assumptions about how the GDML is structured.
 With this in mind, it is best to use the central `detector.gdml` file as 
 the "entrypoint" and comment out the different parts of the detector
 you don't want to see.
+
+#### Tips and Tricks
+- The central `detector.gdml` file asks for other GDML files,
+  so it is best to run this executable _in the same directory_ as the detector
+  description you want to visualize.
+
+- You can make multi-line comments in GDML by using `<!-- ... -->`.
+  For example, the magnetic field is not part of the visualization, but
+  is loaded when constructing the detector. You can ignore this by
+  commenting out the magnetic field part of `detector.gdml`.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ is not well designed for running a visualization. For this reason,
 a small program has been written that loads the input detector
 description GDML file and launches an interactive Geant4 terminal.
 
-The simulation is not well configured, so this interactive terminal
-**should only be used for visualization**.
+The simulation is not well configured in this mode, so this 
+interactive terminal **should only be used for visualization**.
+
+This command is built automatically and is installed as `g4-vis`.
+Run `g4-vis --help` for an explanation on how to use this executable.
 
 #### Common Geant4 Vis Commands
 More detailed documentation for these commands are given in the 
@@ -34,5 +37,4 @@ is launched.
 You will likely want to change the point of view from which you are looking at the
 detector. The [camera working commands](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Visualization/commandcontrol.html#basic-camera-workings-vis-viewer-commands)
 is what Geant4 calls these.
-
 

--- a/src/SimCore/g4_vis.cxx
+++ b/src/SimCore/g4_vis.cxx
@@ -19,7 +19,15 @@ int main(int argc, char* argv[]) {
 
   if (argc != 2) {
     printUsage();
-    std::cerr << "** Need to be given the detector description. **" << std::endl;
+    std::cerr << "** Need to be given a single detector description. **" << std::endl;
+    return 1;
+  }
+
+  std::string the_arg{argv[1]};
+  if (the_arg == "-h" or the_arg == "--help") {
+    // ask for help, let's give it to them.
+    printUsage();
+    return 0;
   }
 
   framework::EventProcessor* null_processor{nullptr};
@@ -35,7 +43,7 @@ int main(int argc, char* argv[]) {
       new simcore::DetectorConstruction(parser, empty_parameters, empty_interface)
       );
   G4GeometryManager::GetInstance()->OpenGeometry();
-  parser->Read(argv[1],false);
+  parser->Read(the_arg,false);
   runManager->DefineWorldVolume(parser->GetWorldVolume());
 
   // required to define a physics list to complete initialization

--- a/src/SimCore/g4_vis.cxx
+++ b/src/SimCore/g4_vis.cxx
@@ -9,7 +9,18 @@
 #include "Framework/EventProcessor.h"
 #include "SimCore/DetectorConstruction.h"
 
+static void printUsage() {
+  std::cout << "usage: g4-vis {detector.gdml}" << std::endl;
+  std::cout << "  {detector.gdml} is the geometry description "
+               "that you wish to visualize." << std::endl;
+}
+
 int main(int argc, char* argv[]) {
+
+  if (argc != 2) {
+    printUsage();
+    std::cerr << "** Need to be given the detector description. **" << std::endl;
+  }
 
   framework::EventProcessor* null_processor{nullptr};
   framework::config::Parameters empty_parameters;
@@ -24,13 +35,12 @@ int main(int argc, char* argv[]) {
       new simcore::DetectorConstruction(parser, empty_parameters, empty_interface)
       );
   G4GeometryManager::GetInstance()->OpenGeometry();
-  parser->Read("detector.gdml",false);
+  parser->Read(argv[1],false);
   runManager->DefineWorldVolume(parser->GetWorldVolume());
 
   // required to define a physics list to complete initialization
   G4PhysListFactory lists;
   runManager->SetUserInitialization(lists.GetReferencePhysList("FTFP_BERT"));
-
 
   runManager->Initialize();
 
@@ -38,15 +48,6 @@ int main(int argc, char* argv[]) {
   G4UIExecutive* ui = new G4UIExecutive(argc, argv);
   G4VisManager* visManager = new G4VisExecutive;
   visManager->Initialize();
-
-  /*
-  G4VVisManager* cli{G4VVisManager::GetConcreteInstance()};
-  if (cli) {
-    cli->ApplyCommand("/vis/open OGL");
-    cli->ApplyCommand("/vis/drawVolume");
-    cli->ApplyCommand("/vis/viewer/flush");
-  }
-  */
 
   ui->SessionStart();
 

--- a/src/SimCore/g4_vis.cxx
+++ b/src/SimCore/g4_vis.cxx
@@ -3,6 +3,7 @@
 #include "G4RunManager.hh"
 #include "G4GDMLParser.hh"
 #include "G4GeometryManager.hh"
+#include "G4PhysListFactory.hh"
 
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventProcessor.h"
@@ -26,10 +27,27 @@ int main(int argc, char* argv[]) {
   parser->Read("detector.gdml",false);
   runManager->DefineWorldVolume(parser->GetWorldVolume());
 
+  // required to define a physics list to complete initialization
+  G4PhysListFactory lists;
+  runManager->SetUserInitialization(lists.GetReferencePhysList("FTFP_BERT"));
+
+
+  runManager->Initialize();
+
   // Define (G)UI
   G4UIExecutive* ui = new G4UIExecutive(argc, argv);
   G4VisManager* visManager = new G4VisExecutive;
   visManager->Initialize();
+
+  /*
+  G4VVisManager* cli{G4VVisManager::GetConcreteInstance()};
+  if (cli) {
+    cli->ApplyCommand("/vis/open OGL");
+    cli->ApplyCommand("/vis/drawVolume");
+    cli->ApplyCommand("/vis/viewer/flush");
+  }
+  */
+
   ui->SessionStart();
 
   delete ui;

--- a/src/SimCore/g4_vis.cxx
+++ b/src/SimCore/g4_vis.cxx
@@ -1,0 +1,41 @@
+#include "G4VisExecutive.hh"
+#include "G4UIExecutive.hh"
+#include "G4RunManager.hh"
+#include "G4GDMLParser.hh"
+#include "G4GeometryManager.hh"
+
+#include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h"
+#include "SimCore/DetectorConstruction.h"
+
+int main(int argc, char* argv[]) {
+
+  framework::EventProcessor* null_processor{nullptr};
+  framework::config::Parameters empty_parameters;
+  simcore::ConditionsInterface empty_interface(null_processor);
+
+  // RunManager 
+  G4RunManager *runManager = new G4RunManager;
+
+  // Detector components
+  auto parser = new G4GDMLParser;
+  runManager->SetUserInitialization(
+      new simcore::DetectorConstruction(parser, empty_parameters, empty_interface)
+      );
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  parser->Read("detector.gdml",false);
+  runManager->DefineWorldVolume(parser->GetWorldVolume());
+
+  // Define (G)UI
+  G4UIExecutive* ui = new G4UIExecutive(argc, argv);
+  G4VisManager* visManager = new G4VisExecutive;
+  visManager->Initialize();
+  ui->SessionStart();
+
+  delete ui;
+  delete runManager;
+  delete visManager;
+
+  return 0;
+}
+


### PR DESCRIPTION
This is a relatively simple addition. I only needed to write the Cpp program and register it as an excecutable in the cmake. The documentation for this program is given in the central README.

The main limitation of this program (as the name implies) is that *it can only do visualization*. After constructing the detector, an interactive Geant4 "terminal" is launched which gives the user access to all the Geant4 commands. The user should only use `/vis/` commands, any attempts at actually running a simulation will (probably) fail because the rest of the simulation is not configured properly.

For container users, you need to pull some tweaks to the container and some changes to ldmx-sw in order to be able to run this visualization from within the container. Below, I outline the (somewhat arduous) total rebuild process which is necessary when switch container environments. At the bottom, I outline basic usage of g4-vis in order to get it to launch.

```bash
cd ldmx-sw
git fetch origin
git checkout iss888 #branch with ldmx-sw tweaks
cd SimCore
git fetch origin
git checkout iss24-tom # this branch for g4-vis
cd ..
rm -r build #if it was there
rm -r install #if it was there
# remove auto-generated files outside build directory
git clean -xi
git submodule foreach 'git clean -xi'

# now we are totally clean
source scripts/ldmx-env.sh
ldmx-container-pull dev display
mkdir build
cd build
ldmx cmake -DBUILD_EVE=ON ..
ldmx make install
cd ..

# launching the detector visualization requires some setup
# it is easiest to simply go to the directory with all the GDML
# files you want to visualize
cd Detectors/data/ldmx-det-v12

# detector construction requires reading in a magnetic field map
# you can sym-link the already installed one here
# alternatively, you can comment out the mag-field-map part
# in detector.gdml
ln -s ../../../install/data/fieldmap/* .

# launch
ldmx g4-vis
```