### PR TITLE
Gamma mumu

### DIFF
--- a/include/SimCore/BiasOperators/GammaToMuPair.h
+++ b/include/SimCore/BiasOperators/GammaToMuPair.h
@@ -1,0 +1,69 @@
+#ifndef SIMCORE_BIASOPERATORS_GAMMATOMUPAIR_H_
+#define SIMCORE_BIASOPERATORS_GAMMATOMUPAIR_H_
+
+#include "SimCore/XsecBiasingOperator.h"
+
+namespace simcore {
+namespace biasoperators {
+
+/**
+ * Bias the Electron-Nuclear process
+ */
+class GammaToMuPair : public XsecBiasingOperator {
+ public:
+  /**
+   * Constructor
+   *
+   * Calls parent constructor and allows
+   * accesss to configuration parameters.
+   */
+  GammaToMuPair(std::string name, const framework::config::Parameters& p);
+
+  /** Destructor */
+  ~GammaToMuPair() {}
+
+  /**
+   * @return Method that returns the biasing operation that will be used
+   *         to bias the occurence of photonuclear events.
+   */
+  G4VBiasingOperation* ProposeOccurenceBiasingOperation(
+      const G4Track* track,
+      const G4BiasingProcessInterface* callingProcess) final override;
+
+  /// Return the process to bias
+  virtual std::string getProcessToBias() const { return "GammaToMuPair"; }
+
+  /// Return the particle to bias
+  virtual std::string getParticleToBias() const { return "gamma"; }
+
+  /// Return the volume to bias in
+  virtual std::string getVolumeToBias() const { return volume_; }
+
+  /**
+   * Record the configuration to the run header
+   *
+   * @param[in,out] header RunHeader to record to
+   */
+  virtual void RecordConfig(ldmx::RunHeader& header) const {
+    header.setStringParameter("BiasOperator::GammaToMuPair::Volume", volume_);
+    header.setFloatParameter("BiasOperator::GammaToMuPair::Factor", factor_);
+    header.setFloatParameter("BiasOperator::GammaToMuPair::Threshold",
+                             threshold_);
+  }
+
+ private:
+  /// The volume to bias in
+  std::string volume_;
+
+  /// The biasing factor
+  double factor_;
+
+  /// Minimum kinetic energy [MeV] to allow a track to be biased
+  double threshold_;
+
+};  // ElectroNuclear
+
+}  // namespace biasoperators
+}  // namespace simcore
+
+#endif  // SIMCORE_BIASOPERATORS_ELECTRONUCLEAR_H_

--- a/include/SimCore/BiasOperators/GammaToMuPair.h
+++ b/include/SimCore/BiasOperators/GammaToMuPair.h
@@ -61,7 +61,7 @@ class GammaToMuPair : public XsecBiasingOperator {
   /// Minimum kinetic energy [MeV] to allow a track to be biased
   double threshold_;
 
-};  // ElectroNuclear
+};
 
 }  // namespace biasoperators
 }  // namespace simcore

--- a/include/SimCore/BiasOperators/GammaToMuPair.h
+++ b/include/SimCore/BiasOperators/GammaToMuPair.h
@@ -24,7 +24,7 @@ class GammaToMuPair : public XsecBiasingOperator {
 
   /**
    * @return Method that returns the biasing operation that will be used
-   *         to bias the occurence of photonuclear events.
+   *         to bias the conversion of gammas to muon pairs.
    */
   G4VBiasingOperation* ProposeOccurenceBiasingOperation(
       const G4Track* track,

--- a/include/SimCore/BiasOperators/GammaToMuPair.h
+++ b/include/SimCore/BiasOperators/GammaToMuPair.h
@@ -7,7 +7,7 @@ namespace simcore {
 namespace biasoperators {
 
 /**
- * Bias the Electron-Nuclear process
+ * Bias the Gamma to Mu Pair process
  */
 class GammaToMuPair : public XsecBiasingOperator {
  public:
@@ -66,4 +66,4 @@ class GammaToMuPair : public XsecBiasingOperator {
 }  // namespace biasoperators
 }  // namespace simcore
 
-#endif  // SIMCORE_BIASOPERATORS_ELECTRONUCLEAR_H_
+#endif  // SIMCORE_BIASOPERATORS_GAMMATOMUPAIR_H_

--- a/include/SimCore/BiasOperators/GammaToMuPair.h
+++ b/include/SimCore/BiasOperators/GammaToMuPair.h
@@ -20,7 +20,7 @@ class GammaToMuPair : public XsecBiasingOperator {
   GammaToMuPair(std::string name, const framework::config::Parameters& p);
 
   /** Destructor */
-  ~GammaToMuPair() {}
+  ~GammaToMuPair() = default;
 
   /**
    * @return Method that returns the biasing operation that will be used

--- a/python/bias_operators.py.in
+++ b/python/bias_operators.py.in
@@ -111,7 +111,7 @@ class GammaToMuPair(XsecBiasingOperator) :
     """
 
     def __init__(self,vol,factor,thresh=0.) :
-        super().__init__('%s_bias_en'%vol,'simcore::biasoperators::GammaToMuPair')
+        super().__init__('%s_bias_mumu'%vol,'simcore::biasoperators::GammaToMuPair')
 
         self.volume = vol
         self.factor = factor

--- a/python/bias_operators.py.in
+++ b/python/bias_operators.py.in
@@ -4,7 +4,7 @@ Mainly focused on reducing the number of places that certain parameter and class
 are hardcoded into the python configuration.
 """
 
-class XsecBiasingOperator: 
+class XsecBiasingOperator:
     """Object that stores parameters for a XsecBiasingOperator
 
     Parameters
@@ -24,7 +24,7 @@ class XsecBiasingOperator:
         from @PYTHON_PACKAGE_NAME@.Framework.ldmxcfg import Process
         Process.addLibrary( '@CMAKE_INSTALL_PREFIX@/lib/lib%s.so'%module_name )
 
-    def __str__(self): 
+    def __str__(self):
         """Stringify this XsecBiasingOperator
 
         Returns
@@ -34,7 +34,7 @@ class XsecBiasingOperator:
         """
 
         string = "XsecBiasingOperator (" + self.__repr__() + ") {"
-        for k, v in self.__dict__.items(): 
+        for k, v in self.__dict__.items():
             string += " %s : %s" % (k, v)
         string += " }"
 
@@ -92,6 +92,26 @@ class ElectroNuclear(XsecBiasingOperator) :
 
     def __init__(self,vol,factor,thresh=0.) :
         super().__init__('%s_bias_en'%vol,'simcore::biasoperators::ElectroNuclear')
+
+        self.volume = vol
+        self.factor = factor
+        self.threshold = thresh
+
+class GammaToMuPair(XsecBiasingOperator) :
+    """Bias gamma -> mu+ mu- process
+
+    Parameters
+    ----------
+    vol : str
+        name of volume to bias within
+    factor : float
+        biasing factor to multiply by
+    threshold : float, optional
+        minimum kinetic energy [MeV] to bias tracks
+    """
+
+    def __init__(self,vol,factor,thresh=0.) :
+        super().__init__('%s_bias_en'%vol,'simcore::biasoperators::GammaToMuPair')
 
         self.volume = vol
         self.factor = factor

--- a/src/SimCore/BiasOperators/GammaToMuPair.cxx
+++ b/src/SimCore/BiasOperators/GammaToMuPair.cxx
@@ -13,37 +13,18 @@ GammaToMuPair::GammaToMuPair(std::string name, const framework::config::Paramete
 
 G4VBiasingOperation* GammaToMuPair::ProposeOccurenceBiasingOperation(
     const G4Track* track, const G4BiasingProcessInterface* callingProcess) {
-  /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
-            << "Track ID: " << track->GetTrackID() << ", "
-            << "Parent ID: " << track->GetParentID() << ", "
-            << "Created within " << track->GetLogicalVolumeAtVertex()->GetName()
-     << ", "
-            << "Currently in volume " << track->GetVolume()->GetName()
-            << std::endl;*/
 
   if (track->GetKineticEnergy() < threshold_) return 0;
-
-  /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
-            << "Calling process: "
-            << callingProcess->GetWrappedProcess()->GetProcessName()
-            << std::endl;*/
 
   std::string currentProcess =
       callingProcess->GetWrappedProcess()->GetProcessName();
   if (currentProcess.compare(this->getProcessToBias()) == 0) {
     G4double interactionLength =
         callingProcess->GetWrappedProcess()->GetCurrentInteractionLength();
-    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
-              << "EN Interaction length: "
-              << interactionLength << std::endl;*/
 
     double enXsecUnbiased = 1. / interactionLength;
-    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: Unbiased EN xsec: "
-              << enXsecUnbiased << std::endl;*/
 
     double enXsecBiased = enXsecUnbiased * factor_;
-    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: Biased EN xsec: "
-              << enXsecBiased << std::endl;*/
 
     return BiasedXsec(enXsecBiased);
   } else

--- a/src/SimCore/BiasOperators/GammaToMuPair.cxx
+++ b/src/SimCore/BiasOperators/GammaToMuPair.cxx
@@ -1,0 +1,56 @@
+
+#include "SimCore/BiasOperators/GammaToMuPair.h"
+
+namespace simcore {
+namespace biasoperators {
+
+GammaToMuPair::GammaToMuPair(std::string name, const framework::config::Parameters& p)
+    : XsecBiasingOperator(name, p) {
+  volume_ = p.getParameter<std::string>("volume");
+  factor_ = p.getParameter<double>("factor");
+  threshold_ = p.getParameter<double>("threshold");
+}
+
+G4VBiasingOperation* GammaToMuPair::ProposeOccurenceBiasingOperation(
+    const G4Track* track, const G4BiasingProcessInterface* callingProcess) {
+  /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
+            << "Track ID: " << track->GetTrackID() << ", "
+            << "Parent ID: " << track->GetParentID() << ", "
+            << "Created within " << track->GetLogicalVolumeAtVertex()->GetName()
+     << ", "
+            << "Currently in volume " << track->GetVolume()->GetName()
+            << std::endl;*/
+
+  if (track->GetKineticEnergy() < threshold_) return 0;
+
+  /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
+            << "Calling process: "
+            << callingProcess->GetWrappedProcess()->GetProcessName()
+            << std::endl;*/
+
+  std::string currentProcess =
+      callingProcess->GetWrappedProcess()->GetProcessName();
+  if (currentProcess.compare(this->getProcessToBias()) == 0) {
+    G4double interactionLength =
+        callingProcess->GetWrappedProcess()->GetCurrentInteractionLength();
+    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: "
+              << "EN Interaction length: "
+              << interactionLength << std::endl;*/
+
+    double enXsecUnbiased = 1. / interactionLength;
+    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: Unbiased EN xsec: "
+              << enXsecUnbiased << std::endl;*/
+
+    double enXsecBiased = enXsecUnbiased * factor_;
+    /*std::cout << "[ ElectroNuclearXsecBiasingOperator ]: Biased EN xsec: "
+              << enXsecBiased << std::endl;*/
+
+    return BiasedXsec(enXsecBiased);
+  } else
+    return 0;
+}
+
+}  // namespace biasoperators
+}  // namespace simcore
+
+DECLARE_XSECBIASINGOPERATOR(simcore::biasoperators, GammaToMuPair)


### PR DESCRIPTION
This pull request makes it possible to bias gamma -> mu+ mu- conversion in the target. It is based on the other biasing operators currently in SimCore. It is mostly independent from the rest of SimCore.

Files added:
include/SimCore/BiasOperators/GammaToMuPair.h
src/SimCore/BiasOperators/GammaToMuPair.cxx 

Files modified:
python/bias_operators.py.in