### PR TITLE
Add new Dark Brem model using DMG4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,38 @@ endif()
 # Configure Geant4
 setup_geant4_target()
 
+# Create an imported DMG4 target if it hasn't been done yet.
+if(NOT TARGET DMG4::Interface)
+  find_path(
+    dmg4_include_dir
+    NAMES DarkMatter.hh
+    PATHS $ENV{LDMX_BASE}/dmg4/install/include /usr/local/include ${DMG4_ROOT}/include)
+
+  if (NOT dmg4_include_dir)
+    message(FATAL_ERROR "DMG4 installation not found. Give the path as
+      '-DDMG4_ROOT=<path-to-install>'.")
+  endif()
+
+  get_filename_component(DMG4_INSTALL_PREFIX ${dmg4_include_dir} DIRECTORY)
+  message(STATUS "Found DMG4: ${DMG4_INSTALL_PREFIX}")
+
+  file(GLOB DMG4_LINK_LIBRARIES CONFIGURE_DEPENDES "${DMG4_INSTALL_PREFIX}/lib*.so")
+
+  # Create the target
+  add_library(DMG4::Interface INTERFACE IMPORTED GLOBAL)
+
+  # Set the target properties
+  set_target_properties(
+    DMG4::Interface
+    PROPERTIES INTERFACE_LINK_LIBRARIES "${DMG4_LINK_LIBRARIES}"
+               INTERFACE_INCLUDE_DIRECTORIES "${DMG4_INSTALL_PREFIX}/include")
+endif()
+
 # Custom A' Physics module (add-on to Geant4)
 setup_library(module SimCore
               name DarkBrem
               dependencies Geant4::Interface
+                           DMG4::Interface
                            ROOT::Physics
                            Framework::Configure
                            Framework::Framework
@@ -116,6 +144,7 @@ if(INSTALL_EXAMPLE_DB_LIBRARIES)
 endif()
 
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/SimCore)
+
 
 # add visualization executable
 add_executable(g4-vis ${PROJECT_SOURCE_DIR}/src/SimCore/g4_vis.cxx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(NOT TARGET DMG4::Interface)
   get_filename_component(DMG4_INSTALL_PREFIX ${dmg4_include_dir} DIRECTORY)
   message(STATUS "Found DMG4: ${DMG4_INSTALL_PREFIX}")
 
-  file(GLOB DMG4_LINK_LIBRARIES CONFIGURE_DEPENDES "${DMG4_INSTALL_PREFIX}/lib*.so")
+  file(GLOB DMG4_LINK_LIBRARIES CONFIGURE_DEPENDES "${DMG4_INSTALL_PREFIX}/lib/lib*.so")
 
   # Create the target
   add_library(DMG4::Interface INTERFACE IMPORTED GLOBAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,39 +37,11 @@ endif()
 # Configure Geant4
 setup_geant4_target()
 
-# Create an imported DMG4 target if it hasn't been done yet.
-if(NOT TARGET DMG4::Interface)
-  find_path(
-    dmg4_include_dir
-    NAMES DarkMatter.hh
-    PATHS $ENV{LDMX_BASE}/dmg4/install/include /usr/local/include ${DMG4_ROOT}/include)
-
-  if (NOT dmg4_include_dir)
-    message(FATAL_ERROR "DMG4 installation not found. Give the path as
-      '-DDMG4_ROOT=<path-to-install>'.")
-    return()
-  endif()
-
-  get_filename_component(DMG4_INSTALL_PREFIX ${dmg4_include_dir} DIRECTORY)
-  message(STATUS "Found DMG4: ${DMG4_INSTALL_PREFIX}")
-
-  file(GLOB DMG4_LINK_LIBRARIES CONFIGURE_DEPENDES "${DMG4_INSTALL_PREFIX}/lib/lib*.so")
-
-  # Create the target
-  add_library(DMG4::Interface INTERFACE IMPORTED GLOBAL)
-
-  # Set the target properties
-  set_target_properties(
-    DMG4::Interface
-    PROPERTIES INTERFACE_LINK_LIBRARIES "${DMG4_LINK_LIBRARIES}"
-               INTERFACE_INCLUDE_DIRECTORIES "${DMG4_INSTALL_PREFIX}/include")
-endif()
-
 # Custom A' Physics module (add-on to Geant4)
 setup_library(module SimCore
               name DarkBrem
               dependencies Geant4::Interface
-                           DMG4::Interface
+                           DMG4 UtilsDM DarkMatter
                            ROOT::Physics
                            Framework::Configure
                            Framework::Framework
@@ -136,7 +108,7 @@ if(INSTALL_EXAMPLE_DB_LIBRARIES)
   # Link to the Framework library
   target_link_libraries(print-dark-brem-xsec-table 
                         PRIVATE Geant4::Interface 
-                                SimCore::SimCore 
+                                SimCore::DarkBrem
                                 Framework::Framework)
   
   # Install the fire executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if(NOT TARGET DMG4::Interface)
   if (NOT dmg4_include_dir)
     message(FATAL_ERROR "DMG4 installation not found. Give the path as
       '-DDMG4_ROOT=<path-to-install>'.")
+    return()
   endif()
 
   get_filename_component(DMG4_INSTALL_PREFIX ${dmg4_include_dir} DIRECTORY)

--- a/include/SimCore/BiasOperators/DarkBrem.h
+++ b/include/SimCore/BiasOperators/DarkBrem.h
@@ -74,7 +74,6 @@ class DarkBrem : public XsecBiasingOperator {
    *
    * This is called inside G4VBiasingOperator::ReportOperationApplied
    * which is called inside G4BiasingProcessInterface::PostStepDoIt
-   */
   void OperationApplied(const G4BiasingProcessInterface* callingProcess,
           G4BiasingAppliedCase biasingCase,
           G4VBiasingOperation* operationApplied,
@@ -91,6 +90,7 @@ class DarkBrem : public XsecBiasingOperator {
               << std::endl;
       }
   }
+   */
 
  private:
   /// volume we want to bias in

--- a/include/SimCore/BiasOperators/DarkBrem.h
+++ b/include/SimCore/BiasOperators/DarkBrem.h
@@ -65,6 +65,16 @@ class DarkBrem : public XsecBiasingOperator {
    */
   virtual void RecordConfig(ldmx::RunHeader& header) const;
 
+  /**
+   * DEBUG FUNCTION
+   */
+  virtual G4VBiasingOperation* ProposeNonPhysicsBiasingOperation(
+      const G4Track* track, 
+      const G4BiasingProcessInterface* callingProcess) final override {
+    std::cout << "NonPhysicsBiasing!!" << std::endl;
+    return 0;
+  }
+
  protected:
   /**
    * DEBUG FUNCTION

--- a/include/SimCore/BiasOperators/DarkBrem.h
+++ b/include/SimCore/BiasOperators/DarkBrem.h
@@ -53,7 +53,7 @@ class DarkBrem : public XsecBiasingOperator {
   }
 
   /// Return the name of the particle this operator biases
-  virtual std::string getParticleToBias() const { return "e-"; }
+  virtual std::string getParticleToBias() const { return particle_; }
 
   /// Return the volume this operator biases
   virtual std::string getVolumeToBias() const { return volume_; }
@@ -74,6 +74,7 @@ class DarkBrem : public XsecBiasingOperator {
    *
    * This is called inside G4VBiasingOperator::ReportOperationApplied
    * which is called inside G4BiasingProcessInterface::PostStepDoIt
+   */
   void OperationApplied(const G4BiasingProcessInterface* callingProcess,
           G4BiasingAppliedCase biasingCase,
           G4VBiasingOperation* operationApplied,
@@ -81,20 +82,22 @@ class DarkBrem : public XsecBiasingOperator {
           G4VBiasingOperation* finalStateOpApplied,
           const G4VParticleChange* particleChangeProduced
           ) {
-      std::string currentProcess =
-  callingProcess->GetWrappedProcess()->GetProcessName(); if
-  (currentProcess.compare(this->getProcessToBias()) == 0) { std::cout << "DB
-  Final State Biasing Operator Applied: "
+      std::string currentProcess = callingProcess->GetWrappedProcess()
+        ->GetProcessName(); 
+      if (currentProcess.compare(this->getProcessToBias()) == 0) { 
+        std::cout << "DB Final State Biasing Operator Applied: "
               << callingProcess->GetProcessName()
               << " -> " << weight*particleChangeProduced->GetWeight()
               << std::endl;
       }
   }
-   */
 
  private:
   /// volume we want to bias in
   std::string volume_;
+
+  /// particle we want to bias
+  std::string particle_;
 
   /// factor we want to bias by
   double factor_;

--- a/include/SimCore/DarkBrem/APrimePhysics.h
+++ b/include/SimCore/DarkBrem/APrimePhysics.h
@@ -101,6 +101,9 @@ class APrimePhysics : public G4VPhysicsConstructor {
   /// is dark brem enabled for this run?
   bool enable_;
 
+  /// link to muons instead of electrons? (EXPERIMENTAL)
+  bool muons_;
+
   /**
    * Dark brem parameters to pass to the process (if enabled)
    *

--- a/include/SimCore/DarkBrem/DMG4Model.h
+++ b/include/SimCore/DarkBrem/DMG4Model.h
@@ -1,59 +1,36 @@
-#ifndef SIMCORE_DARKBREM_DARKBREMVERTEXLIBRARYMODLE_H_
-#define SIMCORE_DARKBREM_DARKBREMVERTEXLIBRARYMODLE_H_
+#ifndef SIMCORE_DARKBREM_DMG4MODEL_H_
+#define SIMCORE_DARKBREM_DMG4MODEL_H_
 
 #include "Framework/Configure/Parameters.h"
 #include "SimCore/DarkBrem/G4eDarkBremsstrahlung.h"
 
-// ROOT
-#include "TLorentzVector.h"
+// DMG4 DarkPhoton Model
+#include "DarkMatter.hh"
+#include "DarkPhotons.hh"
 
 namespace simcore {
 namespace darkbrem {
 
 /**
- * @class DarkBremVertexLibraryModel
+ * @class DMG4Model
  *
- * Geant4 implementation of the model for a particle undergoing a dark brem
- * where we use an imported vertex library to decide the outgoing kinematics.
- *
- * This is where all the heavy lifting in terms of calculating cross sections
- * and actually having an electron do a dark brem occurs. This model depends
- * on severl configurable parameters.
- *
- * - library_path : the full path to the directory containing the LHE dark brem
- *   vertices that will be read in to make the vertex library
- * - epsilon : strength of the dark photon - photon mixing
- * - threshold : minimum energy in GeV for the electron to have a non-zero
- *   cross section for going dark brem
- * - method : scaling method to use to scale the dark brem vertices from
- *   the library to the actual electron energy when a dark brem occurs
- *
- * The required parameter is a vertex library generated in MadGraph
- * (library_path). The other parameters have helpful defaults set in the python
- * configuration class DarkBrem and are there for you to be able to tune this
- * model's behavior. An example library for each of the major mass points is
- * installed with SimCore and is compressed as stored in the data directory.
+ * A model where we use NA64's DMG4 module to compare our
+ * dark brem simulation to theirs.
  */
-class DarkBremVertexLibraryModel : public G4eDarkBremsstrahlungModel {
+class DMG4Model : public G4eDarkBremsstrahlungModel {
  public:
   /**
    * Constructor
    * Set the parameters for this model.
-   *
-   * The method name is converted to an enum through a hard-coded switch
-   * statement.
-   *
-   * The threshold is set to the maximum of the passed value or twice
-   * the A' mass (so that it kinematically makes sense).
-   *
-   * The library path is immediately passed to SetMadGraphDataLibrary.
+   * We pass parameters to the underlying DarkPhoton class
+   * from the DMG4 library.
    */
-  DarkBremVertexLibraryModel(framework::config::Parameters& params);
+  DMG4Model(framework::config::Parameters& params);
 
   /**
    * Destructor
    */
-  virtual ~DarkBremVertexLibraryModel() {}
+  virtual ~DMG4Model() {}
 
   /**
    * Print the configuration of this model
@@ -67,23 +44,10 @@ class DarkBremVertexLibraryModel : public G4eDarkBremsstrahlungModel {
 
   /**
    * Calculates the cross section per atom in GEANT4 internal units.
-   * Uses WW approximation to find the total cross section, performing numerical
-   * integrals over x and theta.
-   *
-   * Numerical integrals are done using boost::numeric::odeint.
-   *
-   * Integrate Chi from \f$m_A^4/(4E_0^2)\f$ to \f$m_A^2\f$
-   *
-   * Integrate DiffCross from 0 to \f$min(1-m_e/E_0,1-m_A/E_0)\f$
-   *
-   * Total cross section is given by
-   * \f[ \sigma = 4 \frac{pb}{GeV} \epsilon^2 \alpha_{EW}^3 \int \chi(t)dt \int
-   * \frac{d\sigma}{dx}(x)dx \f]
    *
    * @param E0 energy of beam (incoming particle)
-   * @param Z atomic number of atom
-   * @param A atomic mass of atom
-   * @param cut minimum energy cut to calculate cross section
+   * @param A atomic mass of atom (unused)
+   * @param Z atomic number of atom (unused)
    * @return cross section (0. if outside energy cuts)
    */
   virtual G4double ComputeCrossSectionPerAtom(G4double electronKE,
@@ -93,22 +57,8 @@ class DarkBremVertexLibraryModel : public G4eDarkBremsstrahlungModel {
   /**
    * Simulates the emission of a dark photon + electron.
    *
-   * Gets an energy fraction and Pt from madgraph files.
-   * The scaling of this energy fraction and Pt to the actual electron
-   * energy depends on the input method.
-   *
-   * ## Forward Only
-   * Scales the energy so that the fraction of kinectic energy is constant,
-   * keeps the Pt constant. If the Pt is larger than the new energy, that event
-   * is skipped, and a new one is taken from the file. Choses the Pz of the
-   * recoil electron to always be positive.
-   *
-   * ## CM Scaling
-   * Scale MadGraph vertex to actual energy of electron using Lorentz boosts,
-   * and then extract the momentum from that.
-   *
-   * ## Undefined
-   * Don't scale the MadGraph vertex to the actual energy of the electron.
+   * Copied over from the DMG4 source code.
+   *  DMG4/src/DMG4/DMProcessDMBrem.cc
    *
    * @param[in,out] particleChange structure holding changes to make to particle
    * track
@@ -119,229 +69,8 @@ class DarkBremVertexLibraryModel : public G4eDarkBremsstrahlungModel {
                               const G4Track& track, const G4Step& step);
 
  private:
-  /**
-   * Set the library of dark brem events to be scaled.
-   * @param file path to directory of LHE files
-   */
-  void SetMadGraphDataLibrary(std::string path);
-
-  /**
-   * Helpful typedef for boost integration.
-   */
-  typedef std::vector<double> StateType;
-
-  /**
-   * @struct Chi
-   *
-   * Stores parameters for chi function used in integration.
-   * Implements function as member operator compatible with
-   * boost::numeric::odeint
-   *
-   * \f[ \chi(t) = \left(
-   * \frac{Z^2a^4t^2}{(1+a^2t)^2(1+t/d)^2}+\frac{Za_p^4t^2}{(1+a_p^2t)^2(1+t/0.71)^8}\left(\frac{1+t(m_{up}^2-1)}{4m_p^2}\right)^2\right)\frac{t-m_A^4/(4E_0^2)}{t^2}
-   * \f]
-   *
-   * where
-   * \f$m_A\f$ = mass of A' in GeV,
-   * \f$m_e\f$ = mass of electron in GeV,
-   * \f$E_0\f$ = incoming energy of electron in GeV,
-   * \f$A\f$ = atomic number of target atom,
-   * \f$Z\f$ = atomic mass of target atom,
-   * \f[a = \frac{111.0}{m_e Z^{1/3}}\f]
-   * \f[a_p = \frac{773.0}{m_e Z^{2/3}}\f]
-   * \f[d = \frac{0.164}{A^{2/3}}\f]
-   * \f$m_{up}\f$ = mass of up quark, and
-   * \f$m_{p}\f$ = mass of proton
-   */
-  struct Chi {
-    /// atomic number
-    double A;
-    /// atomic mass
-    double Z;
-    /// incoming beam energy [GeV]
-    double E0;
-    /// A' mass [GeV]
-    double MA;
-    /// electron mass [GeV]
-    double Mel;
-
-    /**
-     * Access function in style required by boost::numeric::odeint
-     *
-     * Calculates dxdt from t and other paramters.
-     */
-    void operator()(const StateType&, StateType& dxdt, double t);
-  };
-
-  /**
-   * @struct DiffCross
-   *
-   * Implementation of the differential scattering cross section.
-   * Stores parameters.
-   *
-   * Implements function as member operator compatible with
-   * boost::numeric::odeint
-   *
-   * \f[ \frac{d\sigma}{dx}(x) =
-   * \sqrt{1-\frac{m_A^2}{E_0^2}}\frac{1-x+x^2/3}{m_A^2(1-x)/x+m_e^2x} \f]
-   *
-   * where
-   * \f$m_A\f$ = mass of A' in GeV
-   * \f$m_e\f$ = mass of electron in GeV
-   * \f$E_0\f$ = incoming energy of electron in GeV
-   */
-  struct DiffCross {
-    /// incoming beam energy [GeV]
-    double E0;
-    /// A' mass [GeV]
-    double MA;
-    /// electron mass [GeV]
-    double Mel;
-
-    /**
-     * Access function in style required by boost::numeric::odeint
-     *
-     * Calculates DsigmaDx from x and other paramters.
-     */
-    void operator()(const StateType&, StateType& DsigmaDx, double x);
-  };
-
-  /**
-   * @struct OutgoingKinematics
-   *
-   * Data frame to store mad graph data read in from LHE files.
-   */
-  struct OutgoingKinematics {
-    /// 4-momentum of electron in center of momentum frame for electron-A'
-    /// system
-    TLorentzVector electron;
-    /// 4-vector pointing to center of momentum frame
-    TLorentzVector centerMomentum;
-    /// energy of electron before brem (used as key in mad graph data map)
-    G4double E;
-  };
-
-  /*
-   * Parse an LHE File
-   *
-   * Parses an LHE file to extract the kinetic energy fraction and pt of the
-   * outgoing electron in each event. Loads the two numbers from every event
-   * into a map of vectors of pairs (mgdata). Map is keyed by energy, vector
-   * pairs are energy fraction + pt. Also creates an list of energies and
-   * placeholders (energies), so that different energies can be looped
-   * separately.
-   *
-   * @param fname name of LHE file to parse
-   */
-  void ParseLHE(std::string fname);
-
-  /**
-   * Fill vector of currentDataPoints_ with the same number of items as the
-   * madgraph data.
-   *
-   * Randomly choose a starting point so that the simulation run isn't dependent
-   * on the order of LHE vertices in the library.
-   */
-  void MakePlaceholders();
-
-  /**
-   * Returns mad graph data given an energy [GeV].
-   *
-   * Gets the energy fraction and Pt from the imported LHE data.
-   * E0 should be in GeV, returns the total energy and Pt in GeV.
-   * Scales from the closest imported beam energy above the given value (scales
-   * down to avoid biasing issues).
-   *
-   * @param E0 energy of particle undergoing dark brem [GeV]
-   * @return total energy and transverse momentum of particle [GeV]
-   */
-  OutgoingKinematics GetMadgraphData(double E0);
-
- private:
-  /**
-   * maximum number of iterations to check before giving up on an event
-   *
-   * @TODO make configurable and/or optimize somehow
-   */
-  unsigned int maxIterations_{10000};
-
-  /** Threshold for non-zero xsec [GeV]
-   *
-   * Configurable with 'threshold'
-   */
-  double threshold_;
-
-  /** Epsilon value to plug into xsec calculation
-   *
-   * @sa ComputeCrossSectionPerAtom for how this is used
-   *
-   * Configurable with 'epsilon'
-   */
-  double epsilon_;
-
-  /**
-   * @enum DarkBremMethod
-   *
-   * Possible methods to use the dark brem vertices from the imported library
-   * inside of this model.
-   */
-  enum DarkBremMethod {
-    /// Use actual electron energy and get pT from LHE (such that pT^2+me^2 <
-    /// Eacc^2)
-    ForwardOnly = 1,
-    /// Boost LHE vertex momenta to the actual electron energy
-    CMScaling = 2,
-    /// Use LHE vertex as is
-    Undefined = 3
-  };
-
-  /** method for this model
-   *
-   * Configurable with 'method'
-   */
-  DarkBremMethod method_{DarkBremMethod::Undefined};
-
-  /**
-   * Name of method for persisting into the RunHeader
-   */
-  std::string method_name_;
-
-  /**
-   * Full path to the vertex library used for persisting into the RunHeader
-   */
-  std::string library_path_;
-
-  /**
-   * should we always create a totally new electron when we dark brem?
-   *
-   * @TODO make this configurable? I (Tom E) can't think of a reason NOT to have
-   * it... The alternative is to allow Geant4 to decide when to make a new
-   * particle by checking if the resulting kinetic energy is below some
-   * threshold.
-   */
-  bool alwaysCreateNewElectron_{true};
-
-  /**
-   * Storage of data from mad graph
-   *
-   * Maps incoming electron energy to various options for outgoing kinematics.
-   * This is a hefty map and is what stores **all** of the vertices
-   * imported from the LHE library of dark brem vertices.
-   *
-   * Library is read in from configuration parameter 'darkbrem.madgraphlibrary'
-   */
-  std::map<double, std::vector<OutgoingKinematics> > madGraphData_;
-
-  /**
-   * Stores a map of current access points to mad graph data.
-   *
-   * Maps incoming electron energy to the index of the data vector
-   * that we will get the data from.
-   *
-   * Also sorts the incoming electron energy so that we can find
-   * the sampling energy that is closest above the actual incoming energy.
-   */
-  std::map<double, unsigned int> currentDataPoints_;
+  /// model imported from DMG4 library
+  std::unique_ptr<DarkMatter> dm_model_;
 };
 
 }  // namespace darkbrem

--- a/include/SimCore/DarkBrem/DMG4Model.h
+++ b/include/SimCore/DarkBrem/DMG4Model.h
@@ -71,6 +71,8 @@ class DMG4Model : public G4eDarkBremsstrahlungModel {
  private:
   /// model imported from DMG4 library
   std::unique_ptr<DarkMatter> dm_model_;
+  /// the epsilon value we will use
+  double epsilon_;
 };
 
 }  // namespace darkbrem

--- a/include/SimCore/DarkBrem/DMG4Model.h
+++ b/include/SimCore/DarkBrem/DMG4Model.h
@@ -1,0 +1,350 @@
+#ifndef SIMCORE_DARKBREM_DARKBREMVERTEXLIBRARYMODLE_H_
+#define SIMCORE_DARKBREM_DARKBREMVERTEXLIBRARYMODLE_H_
+
+#include "Framework/Configure/Parameters.h"
+#include "SimCore/DarkBrem/G4eDarkBremsstrahlung.h"
+
+// ROOT
+#include "TLorentzVector.h"
+
+namespace simcore {
+namespace darkbrem {
+
+/**
+ * @class DarkBremVertexLibraryModel
+ *
+ * Geant4 implementation of the model for a particle undergoing a dark brem
+ * where we use an imported vertex library to decide the outgoing kinematics.
+ *
+ * This is where all the heavy lifting in terms of calculating cross sections
+ * and actually having an electron do a dark brem occurs. This model depends
+ * on severl configurable parameters.
+ *
+ * - library_path : the full path to the directory containing the LHE dark brem
+ *   vertices that will be read in to make the vertex library
+ * - epsilon : strength of the dark photon - photon mixing
+ * - threshold : minimum energy in GeV for the electron to have a non-zero
+ *   cross section for going dark brem
+ * - method : scaling method to use to scale the dark brem vertices from
+ *   the library to the actual electron energy when a dark brem occurs
+ *
+ * The required parameter is a vertex library generated in MadGraph
+ * (library_path). The other parameters have helpful defaults set in the python
+ * configuration class DarkBrem and are there for you to be able to tune this
+ * model's behavior. An example library for each of the major mass points is
+ * installed with SimCore and is compressed as stored in the data directory.
+ */
+class DarkBremVertexLibraryModel : public G4eDarkBremsstrahlungModel {
+ public:
+  /**
+   * Constructor
+   * Set the parameters for this model.
+   *
+   * The method name is converted to an enum through a hard-coded switch
+   * statement.
+   *
+   * The threshold is set to the maximum of the passed value or twice
+   * the A' mass (so that it kinematically makes sense).
+   *
+   * The library path is immediately passed to SetMadGraphDataLibrary.
+   */
+  DarkBremVertexLibraryModel(framework::config::Parameters& params);
+
+  /**
+   * Destructor
+   */
+  virtual ~DarkBremVertexLibraryModel() {}
+
+  /**
+   * Print the configuration of this model
+   */
+  virtual void PrintInfo() const;
+
+  /**
+   * Record the configuration of this model into the RunHeader
+   */
+  virtual void RecordConfig(ldmx::RunHeader& h) const;
+
+  /**
+   * Calculates the cross section per atom in GEANT4 internal units.
+   * Uses WW approximation to find the total cross section, performing numerical
+   * integrals over x and theta.
+   *
+   * Numerical integrals are done using boost::numeric::odeint.
+   *
+   * Integrate Chi from \f$m_A^4/(4E_0^2)\f$ to \f$m_A^2\f$
+   *
+   * Integrate DiffCross from 0 to \f$min(1-m_e/E_0,1-m_A/E_0)\f$
+   *
+   * Total cross section is given by
+   * \f[ \sigma = 4 \frac{pb}{GeV} \epsilon^2 \alpha_{EW}^3 \int \chi(t)dt \int
+   * \frac{d\sigma}{dx}(x)dx \f]
+   *
+   * @param E0 energy of beam (incoming particle)
+   * @param Z atomic number of atom
+   * @param A atomic mass of atom
+   * @param cut minimum energy cut to calculate cross section
+   * @return cross section (0. if outside energy cuts)
+   */
+  virtual G4double ComputeCrossSectionPerAtom(G4double electronKE,
+                                              G4double atomicA,
+                                              G4double atomicZ);
+
+  /**
+   * Simulates the emission of a dark photon + electron.
+   *
+   * Gets an energy fraction and Pt from madgraph files.
+   * The scaling of this energy fraction and Pt to the actual electron
+   * energy depends on the input method.
+   *
+   * ## Forward Only
+   * Scales the energy so that the fraction of kinectic energy is constant,
+   * keeps the Pt constant. If the Pt is larger than the new energy, that event
+   * is skipped, and a new one is taken from the file. Choses the Pz of the
+   * recoil electron to always be positive.
+   *
+   * ## CM Scaling
+   * Scale MadGraph vertex to actual energy of electron using Lorentz boosts,
+   * and then extract the momentum from that.
+   *
+   * ## Undefined
+   * Don't scale the MadGraph vertex to the actual energy of the electron.
+   *
+   * @param[in,out] particleChange structure holding changes to make to particle
+   * track
+   * @param[in] track current track being processesed
+   * @param[in] step current step of the track
+   */
+  virtual void GenerateChange(G4ParticleChange& particleChange,
+                              const G4Track& track, const G4Step& step);
+
+ private:
+  /**
+   * Set the library of dark brem events to be scaled.
+   * @param file path to directory of LHE files
+   */
+  void SetMadGraphDataLibrary(std::string path);
+
+  /**
+   * Helpful typedef for boost integration.
+   */
+  typedef std::vector<double> StateType;
+
+  /**
+   * @struct Chi
+   *
+   * Stores parameters for chi function used in integration.
+   * Implements function as member operator compatible with
+   * boost::numeric::odeint
+   *
+   * \f[ \chi(t) = \left(
+   * \frac{Z^2a^4t^2}{(1+a^2t)^2(1+t/d)^2}+\frac{Za_p^4t^2}{(1+a_p^2t)^2(1+t/0.71)^8}\left(\frac{1+t(m_{up}^2-1)}{4m_p^2}\right)^2\right)\frac{t-m_A^4/(4E_0^2)}{t^2}
+   * \f]
+   *
+   * where
+   * \f$m_A\f$ = mass of A' in GeV,
+   * \f$m_e\f$ = mass of electron in GeV,
+   * \f$E_0\f$ = incoming energy of electron in GeV,
+   * \f$A\f$ = atomic number of target atom,
+   * \f$Z\f$ = atomic mass of target atom,
+   * \f[a = \frac{111.0}{m_e Z^{1/3}}\f]
+   * \f[a_p = \frac{773.0}{m_e Z^{2/3}}\f]
+   * \f[d = \frac{0.164}{A^{2/3}}\f]
+   * \f$m_{up}\f$ = mass of up quark, and
+   * \f$m_{p}\f$ = mass of proton
+   */
+  struct Chi {
+    /// atomic number
+    double A;
+    /// atomic mass
+    double Z;
+    /// incoming beam energy [GeV]
+    double E0;
+    /// A' mass [GeV]
+    double MA;
+    /// electron mass [GeV]
+    double Mel;
+
+    /**
+     * Access function in style required by boost::numeric::odeint
+     *
+     * Calculates dxdt from t and other paramters.
+     */
+    void operator()(const StateType&, StateType& dxdt, double t);
+  };
+
+  /**
+   * @struct DiffCross
+   *
+   * Implementation of the differential scattering cross section.
+   * Stores parameters.
+   *
+   * Implements function as member operator compatible with
+   * boost::numeric::odeint
+   *
+   * \f[ \frac{d\sigma}{dx}(x) =
+   * \sqrt{1-\frac{m_A^2}{E_0^2}}\frac{1-x+x^2/3}{m_A^2(1-x)/x+m_e^2x} \f]
+   *
+   * where
+   * \f$m_A\f$ = mass of A' in GeV
+   * \f$m_e\f$ = mass of electron in GeV
+   * \f$E_0\f$ = incoming energy of electron in GeV
+   */
+  struct DiffCross {
+    /// incoming beam energy [GeV]
+    double E0;
+    /// A' mass [GeV]
+    double MA;
+    /// electron mass [GeV]
+    double Mel;
+
+    /**
+     * Access function in style required by boost::numeric::odeint
+     *
+     * Calculates DsigmaDx from x and other paramters.
+     */
+    void operator()(const StateType&, StateType& DsigmaDx, double x);
+  };
+
+  /**
+   * @struct OutgoingKinematics
+   *
+   * Data frame to store mad graph data read in from LHE files.
+   */
+  struct OutgoingKinematics {
+    /// 4-momentum of electron in center of momentum frame for electron-A'
+    /// system
+    TLorentzVector electron;
+    /// 4-vector pointing to center of momentum frame
+    TLorentzVector centerMomentum;
+    /// energy of electron before brem (used as key in mad graph data map)
+    G4double E;
+  };
+
+  /*
+   * Parse an LHE File
+   *
+   * Parses an LHE file to extract the kinetic energy fraction and pt of the
+   * outgoing electron in each event. Loads the two numbers from every event
+   * into a map of vectors of pairs (mgdata). Map is keyed by energy, vector
+   * pairs are energy fraction + pt. Also creates an list of energies and
+   * placeholders (energies), so that different energies can be looped
+   * separately.
+   *
+   * @param fname name of LHE file to parse
+   */
+  void ParseLHE(std::string fname);
+
+  /**
+   * Fill vector of currentDataPoints_ with the same number of items as the
+   * madgraph data.
+   *
+   * Randomly choose a starting point so that the simulation run isn't dependent
+   * on the order of LHE vertices in the library.
+   */
+  void MakePlaceholders();
+
+  /**
+   * Returns mad graph data given an energy [GeV].
+   *
+   * Gets the energy fraction and Pt from the imported LHE data.
+   * E0 should be in GeV, returns the total energy and Pt in GeV.
+   * Scales from the closest imported beam energy above the given value (scales
+   * down to avoid biasing issues).
+   *
+   * @param E0 energy of particle undergoing dark brem [GeV]
+   * @return total energy and transverse momentum of particle [GeV]
+   */
+  OutgoingKinematics GetMadgraphData(double E0);
+
+ private:
+  /**
+   * maximum number of iterations to check before giving up on an event
+   *
+   * @TODO make configurable and/or optimize somehow
+   */
+  unsigned int maxIterations_{10000};
+
+  /** Threshold for non-zero xsec [GeV]
+   *
+   * Configurable with 'threshold'
+   */
+  double threshold_;
+
+  /** Epsilon value to plug into xsec calculation
+   *
+   * @sa ComputeCrossSectionPerAtom for how this is used
+   *
+   * Configurable with 'epsilon'
+   */
+  double epsilon_;
+
+  /**
+   * @enum DarkBremMethod
+   *
+   * Possible methods to use the dark brem vertices from the imported library
+   * inside of this model.
+   */
+  enum DarkBremMethod {
+    /// Use actual electron energy and get pT from LHE (such that pT^2+me^2 <
+    /// Eacc^2)
+    ForwardOnly = 1,
+    /// Boost LHE vertex momenta to the actual electron energy
+    CMScaling = 2,
+    /// Use LHE vertex as is
+    Undefined = 3
+  };
+
+  /** method for this model
+   *
+   * Configurable with 'method'
+   */
+  DarkBremMethod method_{DarkBremMethod::Undefined};
+
+  /**
+   * Name of method for persisting into the RunHeader
+   */
+  std::string method_name_;
+
+  /**
+   * Full path to the vertex library used for persisting into the RunHeader
+   */
+  std::string library_path_;
+
+  /**
+   * should we always create a totally new electron when we dark brem?
+   *
+   * @TODO make this configurable? I (Tom E) can't think of a reason NOT to have
+   * it... The alternative is to allow Geant4 to decide when to make a new
+   * particle by checking if the resulting kinetic energy is below some
+   * threshold.
+   */
+  bool alwaysCreateNewElectron_{true};
+
+  /**
+   * Storage of data from mad graph
+   *
+   * Maps incoming electron energy to various options for outgoing kinematics.
+   * This is a hefty map and is what stores **all** of the vertices
+   * imported from the LHE library of dark brem vertices.
+   *
+   * Library is read in from configuration parameter 'darkbrem.madgraphlibrary'
+   */
+  std::map<double, std::vector<OutgoingKinematics> > madGraphData_;
+
+  /**
+   * Stores a map of current access points to mad graph data.
+   *
+   * Maps incoming electron energy to the index of the data vector
+   * that we will get the data from.
+   *
+   * Also sorts the incoming electron energy so that we can find
+   * the sampling energy that is closest above the actual incoming energy.
+   */
+  std::map<double, unsigned int> currentDataPoints_;
+};
+
+}  // namespace darkbrem
+}  // namespace simcore
+
+#endif  // SIMCORE_DARKBREM_DARKBREMVERTEXLIBRARYMODLE_H_

--- a/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
+++ b/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
@@ -344,6 +344,11 @@ class G4eDarkBremsstrahlung : public G4VDiscreteProcess {
   bool only_one_per_event_;
 
   /**
+   * Bias the dark brem cross section GLOBALLY
+   */
+  double global_bias_;
+
+  /**
    * The mass of the A' during this run [MeV]
    */
   double ap_mass_;

--- a/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
+++ b/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
@@ -213,6 +213,12 @@ class G4eDarkBremsstrahlung : public G4VDiscreteProcess {
   static const std::string PROCESS_NAME;
 
   /**
+   * The created instance. This will exist if dark brem has been enabled and _after_
+   * run initialization where the physics lists are constructred
+   */
+  static G4eDarkBremsstrahlung* Get() { return the_process_; }
+
+  /**
    * Constructor
    *
    * Configures this process by doing three main things:
@@ -361,6 +367,8 @@ class G4eDarkBremsstrahlung : public G4VDiscreteProcess {
   framework::logging::logger theLog_ =
       framework::logging::makeLogger("DarkBremProcess");
 
+  /// the created process
+  static G4eDarkBremsstrahlung* the_process_;
 };  // G4eDarkBremsstrahlung
 
 }  // namespace darkbrem

--- a/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
+++ b/include/SimCore/DarkBrem/G4eDarkBremsstrahlung.h
@@ -359,6 +359,11 @@ class G4eDarkBremsstrahlung : public G4VDiscreteProcess {
   bool cache_xsec_;
 
   /**
+   * Are we dark-brem off muons or electrons?
+   */
+  bool muons_;
+
+  /**
    * The model that we are using in this run.
    *
    * Shared with the chaching class.

--- a/include/SimCore/MultiParticleGunPrimaryGenerator.h
+++ b/include/SimCore/MultiParticleGunPrimaryGenerator.h
@@ -39,7 +39,6 @@
 //-------------//
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventHeader.h"
-#include "Recon/Event/EventConstants.h"
 #include "SimCore/PrimaryGenerator.h"
 #include "SimCore/UserPrimaryParticleInformation.h"
 

--- a/python/bias_operators.py.in
+++ b/python/bias_operators.py.in
@@ -169,12 +169,15 @@ class DarkBrem(XsecBiasingOperator) :
         Should we bias all electrons or just the primary?
     factor : float
         biasing factor to mutliply by
+    particle : str
+        which particle to bias (default: 'e-', 'mu-' is experimentally supported)
     """
 
-    def __init__(self,vol,bias_all,factor) :
+    def __init__(self,vol,bias_all,factor,particle = 'e-') :
         super().__init__('%s_bias_darkbrem'%vol,'simcore::biasoperators::DarkBrem')
 
         self.volume = vol
+        self.particle = particle
         self.bias_all = bias_all
         self.factor = factor
 

--- a/python/dark_brem.py
+++ b/python/dark_brem.py
@@ -48,6 +48,22 @@ class VertexLibraryModel(DarkBremModel) :
         self.threshold    = 2.0 #GeV
         self.epsilon      = 0.01
 
+class DMG4Model(DarkBremModel) :
+    """Configuration for the DMG4 model
+
+    Attributes
+    ----------
+    threshold : float
+        Minimum energy [GeV] that electron should have for dark brem to have nonzero xsec
+    epsilon : float
+        Epsilon for dark brem xsec calculation
+    """
+
+    def __init__(self) :
+        super().__init__('dmg4')
+        self.threshold    = 2.0 #GeV
+        self.epsilon      = 0.01
+
 class DarkBrem:
     """Storage for parameters of dark brem process
 

--- a/python/dark_brem.py
+++ b/python/dark_brem.py
@@ -71,6 +71,8 @@ class DarkBrem:
     ----------
     ap_mass : float
         Mass of A' in MeV
+    global_bias : float
+        Biasing factor to apply to the dark brem cross section everywhere (Default: 1.)
     enable : bool
         Should we use the custom Geant4 dark brem process? (Default: No)
     muons : bool
@@ -85,6 +87,7 @@ class DarkBrem:
 
     def __init__(self) : 
         self.ap_mass            = 0.
+        self.global_bias        = 1.
         self.only_one_per_event = False
         self.enable             = False #off by default
         self.muons              = False

--- a/python/dark_brem.py
+++ b/python/dark_brem.py
@@ -73,6 +73,8 @@ class DarkBrem:
         Mass of A' in MeV
     enable : bool
         Should we use the custom Geant4 dark brem process? (Default: No)
+    muons : bool
+        Do dark brem off muons rather than electrons (Default: False)
     only_one_per_event : bool
         Should we deactivate the process after one dark brem or allow for more than one? (Default: No)
     cache_xsec : bool
@@ -85,10 +87,11 @@ class DarkBrem:
         self.ap_mass            = 0.
         self.only_one_per_event = False
         self.enable             = False #off by default
+        self.muons              = False
         self.cache_xsec         = True
         self.model              = DarkBremModel('UNDEFINED')
 
-    def activate(self, ap_mass, model = None) :
+    def activate(self, ap_mass, model = None, muons = False) :
         """Activate the dark brem process with the input A' mass [MeV] and dark brem model
 
         If no dark brem model is given, we do not activate the process
@@ -105,6 +108,8 @@ class DarkBrem:
     
             self.enable = True
             self.model  = model
+
+        self.muons = muons
 
     def __str__(self): 
         """Stringify the DarkBrem configuration

--- a/src/SimCore/BiasOperators/DarkBrem.cxx
+++ b/src/SimCore/BiasOperators/DarkBrem.cxx
@@ -21,6 +21,7 @@ G4VBiasingOperation* DarkBrem::ProposeOccurenceBiasingOperation(
     const G4Track* track, const G4BiasingProcessInterface* callingProcess) {
   std::string currentProcess =
       callingProcess->GetWrappedProcess()->GetProcessName();
+  std::cout << "Biasing " << currentProcess << std::endl;
   if (currentProcess.compare(this->getProcessToBias()) == 0) {
     // bias only the primary particle if we don't want to bias all particles
     if (not bias_all_ and track->GetParentID() != 0) return 0;
@@ -31,11 +32,11 @@ G4VBiasingOperation* DarkBrem::ProposeOccurenceBiasingOperation(
     double dbXsecUnbiased = 1. / interactionLength;
     double dbXsecBiased = dbXsecUnbiased * factor_;
 
-    if (G4RunManager::GetRunManager()->GetVerboseLevel() > 1) {
+//    if (G4RunManager::GetRunManager()->GetVerboseLevel() > 1) {
       std::cout << "[ DarkBremXsecBiasingOperator ]: "
                 << " Unbiased DBrem xsec: " << dbXsecUnbiased
                 << " -> Biased xsec: " << dbXsecBiased << std::endl;
-    }
+//    }
 
     return BiasedXsec(dbXsecBiased);
   } else

--- a/src/SimCore/BiasOperators/DarkBrem.cxx
+++ b/src/SimCore/BiasOperators/DarkBrem.cxx
@@ -12,6 +12,7 @@ namespace biasoperators {
 DarkBrem::DarkBrem(std::string name, const framework::config::Parameters& p)
     : XsecBiasingOperator(name, p) {
   volume_ = p.getParameter<std::string>("volume");
+  particle_ = p.getParameter<std::string>("particle");
   factor_ = p.getParameter<double>("factor");
   bias_all_ = p.getParameter<bool>("bias_all");
 }
@@ -20,6 +21,7 @@ G4VBiasingOperation* DarkBrem::ProposeOccurenceBiasingOperation(
     const G4Track* track, const G4BiasingProcessInterface* callingProcess) {
   std::string currentProcess =
       callingProcess->GetWrappedProcess()->GetProcessName();
+  std::cout << "Biasing called on " << currentProcess << std::endl;
   if (currentProcess.compare(this->getProcessToBias()) == 0) {
     // bias only the primary particle if we don't want to bias all particles
     if (not bias_all_ and track->GetParentID() != 0) return 0;

--- a/src/SimCore/BiasOperators/DarkBrem.cxx
+++ b/src/SimCore/BiasOperators/DarkBrem.cxx
@@ -21,7 +21,6 @@ G4VBiasingOperation* DarkBrem::ProposeOccurenceBiasingOperation(
     const G4Track* track, const G4BiasingProcessInterface* callingProcess) {
   std::string currentProcess =
       callingProcess->GetWrappedProcess()->GetProcessName();
-  std::cout << "Biasing called on " << currentProcess << std::endl;
   if (currentProcess.compare(this->getProcessToBias()) == 0) {
     // bias only the primary particle if we don't want to bias all particles
     if (not bias_all_ and track->GetParentID() != 0) return 0;

--- a/src/SimCore/DarkBrem/APrimePhysics.cxx
+++ b/src/SimCore/DarkBrem/APrimePhysics.cxx
@@ -63,9 +63,7 @@ void APrimePhysics::ConstructProcess() {
     std::cout << "[ APrimePhysics ] : Connecting dark brem to " 
       << particle_def->GetParticleName() << " "
       << particle_def->GetPDGEncoding() << std::endl;
-    G4int ret = particle_def->GetProcessManager()->AddProcess(
-        new G4eDarkBremsstrahlung(parameters_),
-        -1,-1,1000);
+    G4int ret = particle_def->GetProcessManager()->AddDiscreteProcess(new G4eDarkBremsstrahlung(parameters_),1);
     if (ret < 0) {
       EXCEPTION_RAISE("DarkBremReg","Particle process manager returned non-zero status "
           +std::to_string(ret)

--- a/src/SimCore/DarkBrem/APrimePhysics.cxx
+++ b/src/SimCore/DarkBrem/APrimePhysics.cxx
@@ -63,7 +63,9 @@ void APrimePhysics::ConstructProcess() {
     std::cout << "[ APrimePhysics ] : Connecting dark brem to " 
       << particle_def->GetParticleName() << " "
       << particle_def->GetPDGEncoding() << std::endl;
-    G4int ret = particle_def->GetProcessManager()->AddDiscreteProcess(new G4eDarkBremsstrahlung(parameters_),1);
+    auto proc = new G4eDarkBremsstrahlung(parameters_);
+    G4int ret = particle_def->GetProcessManager()->AddDiscreteProcess(proc);
+    //G4int ret = particle_def->GetProcessManager()->AddProcess(proc,-1,1,1);
     if (ret < 0) {
       EXCEPTION_RAISE("DarkBremReg","Particle process manager returned non-zero status "
           +std::to_string(ret)
@@ -72,6 +74,12 @@ void APrimePhysics::ConstructProcess() {
       std::cout << "[ APrimePhysics ] : successfully put dark brem in index " 
         << ret << " of process table." << std::endl;
     }
+    /**
+     * have our custom dark brem process go first in any process ordering
+     */
+    particle_def->GetProcessManager()->SetProcessOrderingToFirst(proc,
+        G4ProcessVectorDoItIndex::idxAll);
+    std::cout << "[ APrimePhysics ] : set dark brem process ordering to first" << std::endl;
   }
 }
 

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -32,13 +32,13 @@ G4double DMG4Model::ComputeCrossSectionPerAtom(
     G4double electronKE, G4double A, G4double Z) {
   electronKE /= GeV; //DMG4 uses GeV internally
   if (electronKE < dm_model_->GetEThresh()) return 0.;  // outside viable region for model
-  return dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor()/epsilon_/epsilon_;
+  return epsilon_*epsilon_*dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor();
 }
 
 void DMG4Model::GenerateChange(
     G4ParticleChange &particleChange, const G4Track &track,
     const G4Step &step) {
-  const G4double incidentE = track.GetTotalEnergy();
+  const G4double incidentE = track.GetKineticEnergy();
   G4ThreeVector incidentDir = track.GetMomentumDirection();
 
   G4double XAcc=0., angles[2];

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -13,6 +13,7 @@ DMG4Model::DMG4Model(framework::config::Parameters &params)
   double apmass = G4APrime::APrime()->GetPDGMass()/CLHEP::GeV;
   double threshold = std::max(params.getParameter<double>("threshold"), 2.*apmass);
   dm_model_ = std::make_unique<DarkPhotons>(apmass,threshold);
+  dm_model_->PrepareTable();
 }
 
 void DMG4Model::PrintInfo() const {

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -35,10 +35,18 @@ G4double DMG4Model::ComputeCrossSectionPerAtom(
   return epsilon_*epsilon_*dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor();
 }
 
+/**
+ * Almost direct copy of DMG4::DMProcessDMBrem::PostStepDoIt
+ *
+ * ## Differences
+ * - removed references to myDarkMatter in favor of dm_model_
+ * - use our A' definition instead of DMG4's
+ * - kill parent lepton and produce new one for easier extraction of kinematics
+ */
 void DMG4Model::GenerateChange(
     G4ParticleChange &particleChange, const G4Track &track,
     const G4Step &step) {
-  const G4double incidentE = track.GetKineticEnergy();
+  const G4double incidentE = track.GetTotalEnergy();
   G4ThreeVector incidentDir = track.GetMomentumDirection();
 
   G4double XAcc=0., angles[2];

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -1,0 +1,451 @@
+
+#include "SimCore/DarkBrem/DarkBremVertexLibraryModel.h"
+
+#include "Framework/Exception/Exception.h"
+#include "Framework/Logger.h"
+#include "SimCore/DarkBrem/G4APrime.h"
+
+// Geant4
+#include "G4Electron.hh"
+#include "G4EventManager.hh"  //for EventID number
+#include "G4PhysicalConstants.hh"
+#include "G4RunManager.hh"  //for VerboseLevel
+#include "G4SystemOfUnits.hh"
+
+// Boost
+#include <boost/numeric/odeint.hpp>
+
+// STL
+#include <dirent.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace simcore {
+namespace darkbrem {
+
+DarkBremVertexLibraryModel::DarkBremVertexLibraryModel(
+    framework::config::Parameters &params)
+    : G4eDarkBremsstrahlungModel(params), method_(DarkBremMethod::Undefined) {
+  method_name_ = params.getParameter<std::string>("method");
+  if (method_name_ == "forward_only") {
+    method_ = DarkBremMethod::ForwardOnly;
+  } else if (method_name_ == "cm_scaling") {
+    method_ = DarkBremMethod::CMScaling;
+  } else if (method_name_ == "undefined") {
+    method_ = DarkBremMethod::Undefined;
+  } else {
+    EXCEPTION_RAISE("InvalidMethod", "Invalid dark brem simulation method '" +
+                                         method_name_ + "'.");
+  }
+
+  threshold_ = std::max(
+      params.getParameter<double>("threshold"),
+      2. * G4APrime::APrime()->GetPDGMass() / CLHEP::GeV  // mass A' in GeV
+  );
+
+  epsilon_ = params.getParameter<double>("epsilon");
+
+  library_path_ = params.getParameter<std::string>("library_path");
+  SetMadGraphDataLibrary(library_path_);
+}
+
+void DarkBremVertexLibraryModel::PrintInfo() const {
+  G4cout << " Dark Brem Vertex Library Model" << G4endl;
+  G4cout << "   Threshold [GeV]: " << threshold_ << G4endl;
+  G4cout << "   Epsilon:         " << epsilon_ << G4endl;
+  G4cout << "   Scaling Method:  " << method_name_ << G4endl;
+  G4cout << "   Vertex Library:  " << library_path_ << G4endl;
+}
+
+void DarkBremVertexLibraryModel::RecordConfig(ldmx::RunHeader &h) const {
+  h.setFloatParameter("Minimum Threshold to DB [GeV]", threshold_);
+  h.setFloatParameter("DB Xsec Epsilon", epsilon_);
+  h.setStringParameter("Vertex Scaling Method", method_name_);
+  h.setStringParameter("Vertex Library", library_path_);
+}
+
+G4double DarkBremVertexLibraryModel::ComputeCrossSectionPerAtom(
+    G4double electronKE, G4double A, G4double Z) {
+  static const double MA =
+      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
+  static const double Mel = G4Electron::Electron()->GetPDGMass() /
+                            CLHEP::GeV;  // mass electron in GeV
+
+  if (electronKE < keV) return 0.;  // outside viable region for model
+
+  electronKE = electronKE / CLHEP::GeV;  // Change energy to GeV.
+
+  // TODO move to first cut above
+  if (electronKE < threshold_) return 0.;  // can't produce a prime
+
+  // begin: chi-formfactor calculation
+  Chi chiformfactor;
+  //  set parameters
+  chiformfactor.A = A;
+  chiformfactor.Z = Z;
+  chiformfactor.E0 = electronKE;
+  chiformfactor.MA = MA;
+  chiformfactor.Mel = Mel;
+
+  double tmin = MA * MA * MA * MA / (4. * electronKE * electronKE);
+  double tmax = MA * MA;
+
+  // Integrate over chi.
+  StateType integral(1);
+  integral[0] = 0.;  // start integral value at zero
+  boost::numeric::odeint::integrate(
+      chiformfactor  // how to calculate integrand
+      ,
+      integral  // integral result
+      ,
+      tmin  // integral lower limit
+      ,
+      tmax  // integral upper limit
+      ,
+      (tmax - tmin) / 1000  // dt - initial, adapts based off error
+  );
+
+  G4double ChiRes = integral[0];
+
+  // Integrate over x. Can use log approximation instead, which falls off at
+  // high A' mass.
+  DiffCross diffcross;
+  diffcross.E0 = electronKE;
+  diffcross.MA = MA;
+  diffcross.Mel = Mel;
+
+  double xmin = 0;
+  double xmax = 1;
+  if ((Mel / electronKE) > (MA / electronKE))
+    xmax = 1 - Mel / electronKE;
+  else
+    xmax = 1 - MA / electronKE;
+
+  // Integrate over differential cross section.
+  integral[0] = 0.;  // start integral value at zero
+  boost::numeric::odeint::integrate(
+      diffcross  // how to calculate integrand
+      ,
+      integral  // integral result
+      ,
+      xmin  // integral lower limit
+      ,
+      xmax  // integral upper limit
+      ,
+      (xmax - xmin) / 1000  // dx - initial, adapts based off error
+  );
+
+  G4double DsDx = integral[0];
+
+  G4double GeVtoPb = 3.894E08;
+  G4double alphaEW = 1.0 / 137.0;
+
+  G4double cross = GeVtoPb * 4. * alphaEW * alphaEW * alphaEW * epsilon_ *
+                   epsilon_ * ChiRes * DsDx * CLHEP::picobarn;
+
+  if (cross < 0.) return 0.;  // safety check all the math
+
+  return cross;
+}
+
+void DarkBremVertexLibraryModel::GenerateChange(
+    G4ParticleChange &particleChange, const G4Track &track,
+    const G4Step &step) {
+  static const double MA =
+      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
+  static const double Mel = G4Electron::Electron()->GetPDGMass() /
+                            CLHEP::GeV;  // mass electron in GeV
+
+  G4double incidentEnergy = step.GetPostStepPoint()->GetTotalEnergy();
+  incidentEnergy =
+      incidentEnergy / CLHEP::GeV;  // Convert the energy to GeV, the units used
+                                    // in the LHE files.
+
+  OutgoingKinematics data = GetMadgraphData(incidentEnergy);
+  double EAcc = (data.electron.E() - Mel) *
+                    ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
+                Mel;
+  double Pt = data.electron.Pt();
+  double P = sqrt(EAcc * EAcc - Mel * Mel);
+  double PhiAcc = data.electron.Phi();
+  if (method_ == DarkBremMethod::ForwardOnly) {
+    unsigned int i = 0;
+    while (Pt * Pt + Mel * Mel > EAcc * EAcc) {
+      // Skip events until the transverse energy is less than the total energy.
+      i++;
+      data = GetMadgraphData(incidentEnergy);
+      EAcc = (data.electron.E() - Mel) *
+                 ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
+             Mel;
+      Pt = data.electron.Pt();
+      P = sqrt(EAcc * EAcc - Mel * Mel);
+      PhiAcc = data.electron.Phi();
+
+      if (i > maxIterations_) {
+        ldmx_log(warn)
+            << "Could not produce a realistic vertex with library energy "
+            << data.electron.E() << " MeV.\n"
+            << "Consider expanding your libary of A' vertices to include a "
+               "beam energy closer to "
+            << incidentEnergy << " MeV.";
+        break;
+      }
+    }
+  } else if (method_ == DarkBremMethod::CMScaling) {
+    TLorentzVector el(data.electron.X(), data.electron.Y(), data.electron.Z(),
+                      data.electron.E());
+    double ediff = data.E - incidentEnergy;
+    TLorentzVector newcm(data.centerMomentum.X(), data.centerMomentum.Y(),
+                         data.centerMomentum.Z() - ediff,
+                         data.centerMomentum.E() - ediff);
+    el.Boost(-1. * data.centerMomentum.BoostVector());
+    el.Boost(newcm.BoostVector());
+    double newE = (data.electron.E() - Mel) *
+                      ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
+                  Mel;
+    el.SetE(newE);
+    EAcc = el.E();
+    Pt = el.Pt();
+    P = el.P();
+  } else if (method_ == DarkBremMethod::Undefined) {
+    EAcc = data.electron.E();
+    P = sqrt(EAcc * EAcc - Mel * Mel);
+    Pt = data.electron.Pt();
+  }
+
+  // What we need:
+  //  - EAcc
+  //  - P and Pt for ThetaAcc
+  //  - PhiAcc
+  // Basically we need the 3-momentum of the recoil electron
+
+  EAcc = EAcc *
+         CLHEP::GeV;  // Change the energy back to MeV, the internal GEANT unit.
+
+  G4double recoilElectronMomentumMag =
+      sqrt(EAcc * EAcc -
+           electron_mass_c2 * electron_mass_c2);  // Electron momentum in MeV.
+  G4ThreeVector recoilElectronMomentum;
+  double ThetaAcc = std::asin(Pt / P);
+  recoilElectronMomentum.set(std::sin(ThetaAcc) * std::cos(PhiAcc),
+                             std::sin(ThetaAcc) * std::sin(PhiAcc),
+                             std::cos(ThetaAcc));
+  recoilElectronMomentum.rotateUz(track.GetMomentumDirection());
+  recoilElectronMomentum.setMag(recoilElectronMomentumMag);
+
+  // create g4dynamicparticle object for the dark photon.
+  // define its 3-momentum so we conserve 3-momentum with primary and recoil
+  // electron NOTE: does _not_ take nucleus recoil into account
+  G4ThreeVector darkPhotonMomentum =
+      track.GetMomentum() - recoilElectronMomentum;
+  G4DynamicParticle *dphoton =
+      new G4DynamicParticle(G4APrime::APrime(), darkPhotonMomentum);
+  // energy of primary
+  G4double finalKE = EAcc - electron_mass_c2;
+
+  // stop tracking and create new secondary instead of primary
+  if (alwaysCreateNewElectron_) {
+    // TODO copy over all other particle information from track I am killing
+    G4DynamicParticle *el = new G4DynamicParticle(
+        track.GetDefinition(),  // should be all electrons right now, but leaves
+                                // positrons open
+        recoilElectronMomentum);
+    particleChange.SetNumberOfSecondaries(2);
+    particleChange.AddSecondary(dphoton);
+    particleChange.AddSecondary(el);
+    particleChange.ProposeTrackStatus(fStopAndKill);
+    // continue tracking
+  } else {
+    // just have primary lose energy (don't rename to different track ID)
+    // TODO untested this branch, not sure if it works as expected
+    particleChange.SetNumberOfSecondaries(1);
+    particleChange.AddSecondary(dphoton);
+    particleChange.ProposeMomentumDirection(recoilElectronMomentum.unit());
+    particleChange.ProposeEnergy(finalKE);
+  }
+}
+
+void DarkBremVertexLibraryModel::SetMadGraphDataLibrary(std::string path) {
+  // Assumptions:
+  //  - Directory passed is a flat directory (no sub directories) containing LHE
+  //  files
+  //  - LHE files are events generated with the correct mass point
+  // TODO automatically select LHE files of the correct mass point?
+
+  bool foundOneFile = false;
+  DIR *dir;            // handle to opened directory
+  struct dirent *ent;  // handle to entry inside directory
+  if ((dir = opendir(path.c_str())) != NULL) {
+    // directory can be opened
+    while ((ent = readdir(dir)) != NULL) {
+      std::string fp = path + '/' + std::string(ent->d_name);
+      if (fp.substr(fp.find_last_of('.') + 1) == "lhe") {
+        // file ends in '.lhe'
+        ParseLHE(fp);
+        foundOneFile = true;
+      }
+    }
+    closedir(dir);
+  }
+
+  if (not foundOneFile) {
+    EXCEPTION_RAISE("DirDNE", "Directory '" + path +
+                                  "' was unable to be opened or no '.lhe' "
+                                  "files were found inside of it.");
+  }
+
+  MakePlaceholders();  // Setup the placeholder offsets for getting data.
+
+  ldmx_log(info) << "MadGraph Library of Dark Brem Vertices:\n";
+  for (const auto &kV : madGraphData_) {
+    ldmx_log(info) << "\t" << std::setw(8) << kV.first << " GeV Beam -> "
+                   << std::setw(6) << kV.second.size() << " Events";
+  }
+
+  return;
+}
+
+void DarkBremVertexLibraryModel::Chi::operator()(const StateType &,
+                                                 StateType &dxdt, double t) {
+  G4double MUp = 2.79;   // mass up quark [GeV]
+  G4double Mpr = 0.938;  // mass proton [GeV]
+
+  G4double d = 0.164 / pow(A, 2. / 3.);
+  G4double ap = 773.0 / (Mel * pow(Z, 2. / 3.));
+  G4double a = 111.0 / (Mel * pow(Z, 1. / 3.));
+  G4double G2el = pow(Z, 2) * pow(a, 4) * pow(t, 2) /
+                  (pow(1.0 + a * a * t, 2) * pow(1.0 + t / d, 2));
+  G4double G2in = Z * pow(ap, 4) * pow(t, 2) /
+                  (pow(1.0 + ap * ap * t, 2) * pow(1.0 + t / 0.71, 8)) *
+                  pow(1.0 + t * (pow(MUp, 2) - 1.0) / (4.0 * pow(Mpr, 2)), 2);
+  G4double G2 = G2el + G2in;
+  G4double ttmin = MA * MA * MA * MA / 4.0 / E0 / E0;
+  G4double Under = G2 * (t - ttmin) / t / t;
+
+  dxdt[0] = Under;
+
+  return;
+}
+
+void DarkBremVertexLibraryModel::DiffCross::operator()(const StateType &,
+                                                       StateType &DsigmaDx,
+                                                       double x) {
+  G4double beta = sqrt(1 - MA * MA / E0 / E0);
+  G4double num = 1. - x + x * x / 3.;
+  G4double denom = MA * MA * (1. - x) / x + Mel * Mel * x;
+
+  DsigmaDx[0] = beta * num / denom;
+
+  return;
+}
+
+void DarkBremVertexLibraryModel::ParseLHE(std::string fname) {
+  static const double MA =
+      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
+
+  // TODO: use already written LHE parser?
+  ldmx_log(info) << "Parsing LHE file '" << fname << "'... ";
+
+  std::ifstream ifile;
+  ifile.open(fname.c_str());
+  if (!ifile) {
+    EXCEPTION_RAISE("LHEFile", "Unable to open LHE file '" + fname + "'.");
+  }
+
+  std::string line;
+  while (std::getline(ifile, line)) {
+    std::istringstream iss(line);
+    int ptype, state;
+    double skip, px, py, pz, E, M;
+    if (iss >> ptype >> state >> skip >> skip >> skip >> skip >> px >> py >>
+        pz >> E >> M) {
+      if ((ptype == 11) && (state == -1)) {
+        double ebeam = E;
+        double e_px, e_py, e_pz, a_px, a_py, a_pz, e_E, a_E, e_M, a_M;
+        for (int i = 0; i < 2; i++) {
+          std::getline(ifile, line);
+        }
+        std::istringstream jss(line);
+        jss >> ptype >> state >> skip >> skip >> skip >> skip >> e_px >> e_py >>
+            e_pz >> e_E >> e_M;
+        if ((ptype == 11) && (state == 1)) {  // Find a final state electron.
+          for (int i = 0; i < 2; i++) {
+            std::getline(ifile, line);
+          }
+          std::istringstream kss(line);
+          kss >> ptype >> state >> skip >> skip >> skip >> skip >> a_px >>
+              a_py >> a_pz >> a_E >> a_M;
+          if (ptype == 622 and state == 1) {
+            if (abs(1. - a_M / MA) > 1e-3) {
+              EXCEPTION_RAISE("BadMGEvnt",
+                              "A MadGraph imported event has a different "
+                              "APrime mass than the model has (MadGraph = " +
+                                  std::to_string(a_M) + "GeV; Model = " +
+                                  std::to_string(MA) + "GeV).");
+            }
+            OutgoingKinematics evnt;
+            double cmpx = a_px + e_px;
+            double cmpy = a_py + e_py;
+            double cmpz = a_pz + e_pz;
+            double cmE = a_E + e_E;
+            evnt.electron = TLorentzVector(e_px, e_py, e_pz, e_E);
+            evnt.centerMomentum = TLorentzVector(cmpx, cmpy, cmpz, cmE);
+            evnt.E = ebeam;
+            madGraphData_[ebeam].push_back(evnt);
+          }  // get a prime kinematics
+        }    // check for final state
+      }      // check for particle type and state
+    }        // able to get momentum/energy numbers
+  }          // while getting lines
+  // Add the energy to the list, with a random offset between 0 and the total
+  // number of entries.
+  ifile.close();
+  ldmx_log(info) << "done parsing.";
+}
+
+void DarkBremVertexLibraryModel::MakePlaceholders() {
+  currentDataPoints_.clear();
+  maxIterations_ = 10000;
+  for (const auto &iter : madGraphData_) {
+    currentDataPoints_[iter.first] = int(G4UniformRand() * iter.second.size());
+    if (iter.second.size() < maxIterations_)
+      maxIterations_ = iter.second.size();
+  }
+}
+
+DarkBremVertexLibraryModel::OutgoingKinematics
+DarkBremVertexLibraryModel::GetMadgraphData(double E0) {
+  OutgoingKinematics cmdata;  // data frame to return
+
+  // Cycle through imported beam energies until the closest one above is found,
+  // or the max is reached.
+  double samplingE = 0.;
+  for (const auto &keyVal : currentDataPoints_) {
+    samplingE = keyVal.first;  // move samplingE up
+    // check if went under the sampling energy
+    //  the map is sorted by key, so we can be done right after E0 goes under
+    //  samplingE
+    if (E0 < samplingE) break;
+  }
+  // now samplingE is the closest energy above E0 or the maximum energy imported
+  // from mad graph
+
+  // Need to loop around if we hit the end, when the size of
+  // madGraphData_[samplingE] is smaller than
+  //  the number of events we want
+  if (currentDataPoints_.at(samplingE) >= madGraphData_.at(samplingE).size()) {
+    currentDataPoints_[samplingE] = 0;
+  }
+
+  // Get the lorentz vectors from the index given by the placeholder.
+  cmdata = madGraphData_.at(samplingE).at(currentDataPoints_.at(samplingE));
+
+  // Increment the current index
+  currentDataPoints_[samplingE]++;
+
+  return cmdata;
+}
+
+}  // namespace darkbrem
+}  // namespace simcore

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -12,6 +12,7 @@ DMG4Model::DMG4Model(framework::config::Parameters &params)
     : G4eDarkBremsstrahlungModel(params) {
   double apmass = G4APrime::APrime()->GetPDGMass()/CLHEP::GeV;
   double threshold = std::max(params.getParameter<double>("threshold"), 2.*apmass);
+  epsilon_ = params.getParameter<double>("epsilon");
   dm_model_ = std::make_unique<DarkPhotons>(apmass,threshold);
   dm_model_->PrepareTable();
 }
@@ -31,7 +32,7 @@ G4double DMG4Model::ComputeCrossSectionPerAtom(
     G4double electronKE, G4double A, G4double Z) {
   electronKE /= GeV; //DMG4 uses GeV internally
   if (electronKE < dm_model_->GetEThresh()) return 0.;  // outside viable region for model
-  return dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor();
+  return dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor()/epsilon_/epsilon_;
 }
 
 void DMG4Model::GenerateChange(

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -48,6 +48,7 @@ void DMG4Model::GenerateChange(
     const G4Step &step) {
   const G4double incidentE = track.GetTotalEnergy();
   G4ThreeVector incidentDir = track.GetMomentumDirection();
+  const G4double incidentKinE = track.GetKineticEnergy();
 
   G4double XAcc=0., angles[2];
   if(dm_model_->GetParentPDGID() == 11)
@@ -57,13 +58,15 @@ void DMG4Model::GenerateChange(
       XAcc = dm_model_->SimulateEmission(incidentE/GeV, angles);
     }
   if(dm_model_->GetParentPDGID() == 13) {
-    //XAcc = dm_model_->SimulateEmission(incidentE/GeV, angles);
-    XAcc = dm_model_->SimulateEmissionByMuon(incidentE/GeV, angles); // angles are for the recoil muon
+    // 2-dim sampling, angles are for the recoil muon
+    //XAcc = dm_model_->SimulateEmissionByMuon(incidentE/GeV, angles);
+    // 2-step sampling, angles are for the recoil muon
+    XAcc = dm_model_->SimulateEmissionByMuon2(incidentE/GeV, angles); 
   }
 
   // Check if it failed? In this case XAcc = 0
 
-  G4double recoilE = incidentE * (1. - XAcc),
+  G4double recoilE = incidentKinE - incidentE * XAcc,
            recoilTheta = 0.,
            recoilPhi = 0.;
   G4double DMTheta = angles[0], DMPhi = angles[1];

--- a/src/SimCore/DarkBrem/DMG4Model.cxx
+++ b/src/SimCore/DarkBrem/DMG4Model.cxx
@@ -1,450 +1,93 @@
 
-#include "SimCore/DarkBrem/DarkBremVertexLibraryModel.h"
+#include "SimCore/DarkBrem/DMG4Model.h"
 
 #include "Framework/Exception/Exception.h"
 #include "Framework/Logger.h"
 #include "SimCore/DarkBrem/G4APrime.h"
 
-// Geant4
-#include "G4Electron.hh"
-#include "G4EventManager.hh"  //for EventID number
-#include "G4PhysicalConstants.hh"
-#include "G4RunManager.hh"  //for VerboseLevel
-#include "G4SystemOfUnits.hh"
-
-// Boost
-#include <boost/numeric/odeint.hpp>
-
-// STL
-#include <dirent.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 namespace simcore {
 namespace darkbrem {
 
-DarkBremVertexLibraryModel::DarkBremVertexLibraryModel(
-    framework::config::Parameters &params)
-    : G4eDarkBremsstrahlungModel(params), method_(DarkBremMethod::Undefined) {
-  method_name_ = params.getParameter<std::string>("method");
-  if (method_name_ == "forward_only") {
-    method_ = DarkBremMethod::ForwardOnly;
-  } else if (method_name_ == "cm_scaling") {
-    method_ = DarkBremMethod::CMScaling;
-  } else if (method_name_ == "undefined") {
-    method_ = DarkBremMethod::Undefined;
-  } else {
-    EXCEPTION_RAISE("InvalidMethod", "Invalid dark brem simulation method '" +
-                                         method_name_ + "'.");
-  }
-
-  threshold_ = std::max(
-      params.getParameter<double>("threshold"),
-      2. * G4APrime::APrime()->GetPDGMass() / CLHEP::GeV  // mass A' in GeV
-  );
-
-  epsilon_ = params.getParameter<double>("epsilon");
-
-  library_path_ = params.getParameter<std::string>("library_path");
-  SetMadGraphDataLibrary(library_path_);
+DMG4Model::DMG4Model(framework::config::Parameters &params)
+    : G4eDarkBremsstrahlungModel(params) {
+  double apmass = G4APrime::APrime()->GetPDGMass()/CLHEP::GeV;
+  double threshold = std::max(params.getParameter<double>("threshold"), 2.*apmass);
+  dm_model_ = std::make_unique<DarkPhotons>(apmass,threshold);
 }
 
-void DarkBremVertexLibraryModel::PrintInfo() const {
-  G4cout << " Dark Brem Vertex Library Model" << G4endl;
-  G4cout << "   Threshold [GeV]: " << threshold_ << G4endl;
-  G4cout << "   Epsilon:         " << epsilon_ << G4endl;
-  G4cout << "   Scaling Method:  " << method_name_ << G4endl;
-  G4cout << "   Vertex Library:  " << library_path_ << G4endl;
+void DMG4Model::PrintInfo() const {
+  G4cout << " DMG4 DarkPhotons Model" << G4endl;
+  G4cout << "   Threshold [GeV]: " << dm_model_->GetEThresh() << G4endl;
+  G4cout << "   Epsilon:         " << dm_model_->Getepsil() << G4endl;
 }
 
-void DarkBremVertexLibraryModel::RecordConfig(ldmx::RunHeader &h) const {
-  h.setFloatParameter("Minimum Threshold to DB [GeV]", threshold_);
-  h.setFloatParameter("DB Xsec Epsilon", epsilon_);
-  h.setStringParameter("Vertex Scaling Method", method_name_);
-  h.setStringParameter("Vertex Library", library_path_);
+void DMG4Model::RecordConfig(ldmx::RunHeader &h) const {
+  h.setFloatParameter("Minimum Threshold to DB [GeV]", dm_model_->GetEThresh());
+  h.setFloatParameter("DB Xsec Epsilon", dm_model_->Getepsil());
 }
 
-G4double DarkBremVertexLibraryModel::ComputeCrossSectionPerAtom(
+G4double DMG4Model::ComputeCrossSectionPerAtom(
     G4double electronKE, G4double A, G4double Z) {
-  static const double MA =
-      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
-  static const double Mel = G4Electron::Electron()->GetPDGMass() /
-                            CLHEP::GeV;  // mass electron in GeV
-
-  if (electronKE < keV) return 0.;  // outside viable region for model
-
-  electronKE = electronKE / CLHEP::GeV;  // Change energy to GeV.
-
-  // TODO move to first cut above
-  if (electronKE < threshold_) return 0.;  // can't produce a prime
-
-  // begin: chi-formfactor calculation
-  Chi chiformfactor;
-  //  set parameters
-  chiformfactor.A = A;
-  chiformfactor.Z = Z;
-  chiformfactor.E0 = electronKE;
-  chiformfactor.MA = MA;
-  chiformfactor.Mel = Mel;
-
-  double tmin = MA * MA * MA * MA / (4. * electronKE * electronKE);
-  double tmax = MA * MA;
-
-  // Integrate over chi.
-  StateType integral(1);
-  integral[0] = 0.;  // start integral value at zero
-  boost::numeric::odeint::integrate(
-      chiformfactor  // how to calculate integrand
-      ,
-      integral  // integral result
-      ,
-      tmin  // integral lower limit
-      ,
-      tmax  // integral upper limit
-      ,
-      (tmax - tmin) / 1000  // dt - initial, adapts based off error
-  );
-
-  G4double ChiRes = integral[0];
-
-  // Integrate over x. Can use log approximation instead, which falls off at
-  // high A' mass.
-  DiffCross diffcross;
-  diffcross.E0 = electronKE;
-  diffcross.MA = MA;
-  diffcross.Mel = Mel;
-
-  double xmin = 0;
-  double xmax = 1;
-  if ((Mel / electronKE) > (MA / electronKE))
-    xmax = 1 - Mel / electronKE;
-  else
-    xmax = 1 - MA / electronKE;
-
-  // Integrate over differential cross section.
-  integral[0] = 0.;  // start integral value at zero
-  boost::numeric::odeint::integrate(
-      diffcross  // how to calculate integrand
-      ,
-      integral  // integral result
-      ,
-      xmin  // integral lower limit
-      ,
-      xmax  // integral upper limit
-      ,
-      (xmax - xmin) / 1000  // dx - initial, adapts based off error
-  );
-
-  G4double DsDx = integral[0];
-
-  G4double GeVtoPb = 3.894E08;
-  G4double alphaEW = 1.0 / 137.0;
-
-  G4double cross = GeVtoPb * 4. * alphaEW * alphaEW * alphaEW * epsilon_ *
-                   epsilon_ * ChiRes * DsDx * CLHEP::picobarn;
-
-  if (cross < 0.) return 0.;  // safety check all the math
-
-  return cross;
+  electronKE /= GeV; //DMG4 uses GeV internally
+  if (electronKE < dm_model_->GetEThresh()) return 0.;  // outside viable region for model
+  return dm_model_->GetSigmaTot(electronKE)/dm_model_->GetMeanFreePathFactor();
 }
 
-void DarkBremVertexLibraryModel::GenerateChange(
+void DMG4Model::GenerateChange(
     G4ParticleChange &particleChange, const G4Track &track,
     const G4Step &step) {
-  static const double MA =
-      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
-  static const double Mel = G4Electron::Electron()->GetPDGMass() /
-                            CLHEP::GeV;  // mass electron in GeV
+  const G4double incidentE = track.GetTotalEnergy();
+  G4ThreeVector incidentDir = track.GetMomentumDirection();
 
-  G4double incidentEnergy = step.GetPostStepPoint()->GetTotalEnergy();
-  incidentEnergy =
-      incidentEnergy / CLHEP::GeV;  // Convert the energy to GeV, the units used
-                                    // in the LHE files.
-
-  OutgoingKinematics data = GetMadgraphData(incidentEnergy);
-  double EAcc = (data.electron.E() - Mel) *
-                    ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
-                Mel;
-  double Pt = data.electron.Pt();
-  double P = sqrt(EAcc * EAcc - Mel * Mel);
-  double PhiAcc = data.electron.Phi();
-  if (method_ == DarkBremMethod::ForwardOnly) {
-    unsigned int i = 0;
-    while (Pt * Pt + Mel * Mel > EAcc * EAcc) {
-      // Skip events until the transverse energy is less than the total energy.
-      i++;
-      data = GetMadgraphData(incidentEnergy);
-      EAcc = (data.electron.E() - Mel) *
-                 ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
-             Mel;
-      Pt = data.electron.Pt();
-      P = sqrt(EAcc * EAcc - Mel * Mel);
-      PhiAcc = data.electron.Phi();
-
-      if (i > maxIterations_) {
-        ldmx_log(warn)
-            << "Could not produce a realistic vertex with library energy "
-            << data.electron.E() << " MeV.\n"
-            << "Consider expanding your libary of A' vertices to include a "
-               "beam energy closer to "
-            << incidentEnergy << " MeV.";
-        break;
-      }
+  G4double XAcc=0., angles[2];
+  if(dm_model_->GetParentPDGID() == 11)
+    if(dm_model_->Decay()) {
+      XAcc = dm_model_->SimulateEmissionWithAngle2(incidentE/GeV, angles);
+    } else {
+      XAcc = dm_model_->SimulateEmission(incidentE/GeV, angles);
     }
-  } else if (method_ == DarkBremMethod::CMScaling) {
-    TLorentzVector el(data.electron.X(), data.electron.Y(), data.electron.Z(),
-                      data.electron.E());
-    double ediff = data.E - incidentEnergy;
-    TLorentzVector newcm(data.centerMomentum.X(), data.centerMomentum.Y(),
-                         data.centerMomentum.Z() - ediff,
-                         data.centerMomentum.E() - ediff);
-    el.Boost(-1. * data.centerMomentum.BoostVector());
-    el.Boost(newcm.BoostVector());
-    double newE = (data.electron.E() - Mel) *
-                      ((incidentEnergy - Mel - MA) / (data.E - Mel - MA)) +
-                  Mel;
-    el.SetE(newE);
-    EAcc = el.E();
-    Pt = el.Pt();
-    P = el.P();
-  } else if (method_ == DarkBremMethod::Undefined) {
-    EAcc = data.electron.E();
-    P = sqrt(EAcc * EAcc - Mel * Mel);
-    Pt = data.electron.Pt();
+  if(dm_model_->GetParentPDGID() == 13) {
+    //XAcc = dm_model_->SimulateEmission(incidentE/GeV, angles);
+    XAcc = dm_model_->SimulateEmissionByMuon(incidentE/GeV, angles); // angles are for the recoil muon
   }
 
-  // What we need:
-  //  - EAcc
-  //  - P and Pt for ThetaAcc
-  //  - PhiAcc
-  // Basically we need the 3-momentum of the recoil electron
+  // Check if it failed? In this case XAcc = 0
 
-  EAcc = EAcc *
-         CLHEP::GeV;  // Change the energy back to MeV, the internal GEANT unit.
-
-  G4double recoilElectronMomentumMag =
-      sqrt(EAcc * EAcc -
-           electron_mass_c2 * electron_mass_c2);  // Electron momentum in MeV.
-  G4ThreeVector recoilElectronMomentum;
-  double ThetaAcc = std::asin(Pt / P);
-  recoilElectronMomentum.set(std::sin(ThetaAcc) * std::cos(PhiAcc),
-                             std::sin(ThetaAcc) * std::sin(PhiAcc),
-                             std::cos(ThetaAcc));
-  recoilElectronMomentum.rotateUz(track.GetMomentumDirection());
-  recoilElectronMomentum.setMag(recoilElectronMomentumMag);
-
-  // create g4dynamicparticle object for the dark photon.
-  // define its 3-momentum so we conserve 3-momentum with primary and recoil
-  // electron NOTE: does _not_ take nucleus recoil into account
-  G4ThreeVector darkPhotonMomentum =
-      track.GetMomentum() - recoilElectronMomentum;
-  G4DynamicParticle *dphoton =
-      new G4DynamicParticle(G4APrime::APrime(), darkPhotonMomentum);
-  // energy of primary
-  G4double finalKE = EAcc - electron_mass_c2;
-
-  // stop tracking and create new secondary instead of primary
-  if (alwaysCreateNewElectron_) {
-    // TODO copy over all other particle information from track I am killing
-    G4DynamicParticle *el = new G4DynamicParticle(
-        track.GetDefinition(),  // should be all electrons right now, but leaves
-                                // positrons open
-        recoilElectronMomentum);
-    particleChange.SetNumberOfSecondaries(2);
-    particleChange.AddSecondary(dphoton);
-    particleChange.AddSecondary(el);
-    particleChange.ProposeTrackStatus(fStopAndKill);
-    // continue tracking
-  } else {
-    // just have primary lose energy (don't rename to different track ID)
-    // TODO untested this branch, not sure if it works as expected
-    particleChange.SetNumberOfSecondaries(1);
-    particleChange.AddSecondary(dphoton);
-    particleChange.ProposeMomentumDirection(recoilElectronMomentum.unit());
-    particleChange.ProposeEnergy(finalKE);
+  G4double recoilE = incidentE * (1. - XAcc),
+           recoilTheta = 0.,
+           recoilPhi = 0.;
+  G4double DMTheta = angles[0], DMPhi = angles[1];
+  if(dm_model_->GetParentPDGID() == 13) {
+    recoilTheta = angles[0];
+    recoilPhi = angles[1];
+    DMTheta = 0.;
+    DMPhi = 0.;
   }
-}
+  G4double DME = incidentE * XAcc;
+  G4double DMM = dm_model_->GetMA()*GeV;
+  G4double DMKinE = DME*DME - DMM*DMM;
+  if(DMKinE < 0.) DMKinE = 0.;
+  DMKinE = sqrt(DMKinE);
 
-void DarkBremVertexLibraryModel::SetMadGraphDataLibrary(std::string path) {
-  // Assumptions:
-  //  - Directory passed is a flat directory (no sub directories) containing LHE
-  //  files
-  //  - LHE files are events generated with the correct mass point
-  // TODO automatically select LHE files of the correct mass point?
+  // Initialize DM direction vector:
+  G4ThreeVector DMDirection(0., 0., .1);
+  DMDirection.setMag(1.);
+  DMDirection.setTheta( DMTheta );
+  DMDirection.setPhi( DMPhi );
+  DMDirection.rotateUz(incidentDir);
+  // Initialize new projectile particle direction vector:
+  G4ThreeVector projDirection(0., 0., 1.);
+  projDirection.setMag(1.);
+  projDirection.setTheta( recoilTheta );
+  projDirection.setPhi( recoilPhi );
+  projDirection.rotateUz(incidentDir);
 
-  bool foundOneFile = false;
-  DIR *dir;            // handle to opened directory
-  struct dirent *ent;  // handle to entry inside directory
-  if ((dir = opendir(path.c_str())) != NULL) {
-    // directory can be opened
-    while ((ent = readdir(dir)) != NULL) {
-      std::string fp = path + '/' + std::string(ent->d_name);
-      if (fp.substr(fp.find_last_of('.') + 1) == "lhe") {
-        // file ends in '.lhe'
-        ParseLHE(fp);
-        foundOneFile = true;
-      }
-    }
-    closedir(dir);
-  }
-
-  if (not foundOneFile) {
-    EXCEPTION_RAISE("DirDNE", "Directory '" + path +
-                                  "' was unable to be opened or no '.lhe' "
-                                  "files were found inside of it.");
-  }
-
-  MakePlaceholders();  // Setup the placeholder offsets for getting data.
-
-  ldmx_log(info) << "MadGraph Library of Dark Brem Vertices:\n";
-  for (const auto &kV : madGraphData_) {
-    ldmx_log(info) << "\t" << std::setw(8) << kV.first << " GeV Beam -> "
-                   << std::setw(6) << kV.second.size() << " Events";
-  }
-
-  return;
-}
-
-void DarkBremVertexLibraryModel::Chi::operator()(const StateType &,
-                                                 StateType &dxdt, double t) {
-  G4double MUp = 2.79;   // mass up quark [GeV]
-  G4double Mpr = 0.938;  // mass proton [GeV]
-
-  G4double d = 0.164 / pow(A, 2. / 3.);
-  G4double ap = 773.0 / (Mel * pow(Z, 2. / 3.));
-  G4double a = 111.0 / (Mel * pow(Z, 1. / 3.));
-  G4double G2el = pow(Z, 2) * pow(a, 4) * pow(t, 2) /
-                  (pow(1.0 + a * a * t, 2) * pow(1.0 + t / d, 2));
-  G4double G2in = Z * pow(ap, 4) * pow(t, 2) /
-                  (pow(1.0 + ap * ap * t, 2) * pow(1.0 + t / 0.71, 8)) *
-                  pow(1.0 + t * (pow(MUp, 2) - 1.0) / (4.0 * pow(Mpr, 2)), 2);
-  G4double G2 = G2el + G2in;
-  G4double ttmin = MA * MA * MA * MA / 4.0 / E0 / E0;
-  G4double Under = G2 * (t - ttmin) / t / t;
-
-  dxdt[0] = Under;
-
-  return;
-}
-
-void DarkBremVertexLibraryModel::DiffCross::operator()(const StateType &,
-                                                       StateType &DsigmaDx,
-                                                       double x) {
-  G4double beta = sqrt(1 - MA * MA / E0 / E0);
-  G4double num = 1. - x + x * x / 3.;
-  G4double denom = MA * MA * (1. - x) / x + Mel * Mel * x;
-
-  DsigmaDx[0] = beta * num / denom;
-
-  return;
-}
-
-void DarkBremVertexLibraryModel::ParseLHE(std::string fname) {
-  static const double MA =
-      G4APrime::APrime()->GetPDGMass() / CLHEP::GeV;  // mass A' in GeV
-
-  // TODO: use already written LHE parser?
-  ldmx_log(info) << "Parsing LHE file '" << fname << "'... ";
-
-  std::ifstream ifile;
-  ifile.open(fname.c_str());
-  if (!ifile) {
-    EXCEPTION_RAISE("LHEFile", "Unable to open LHE file '" + fname + "'.");
-  }
-
-  std::string line;
-  while (std::getline(ifile, line)) {
-    std::istringstream iss(line);
-    int ptype, state;
-    double skip, px, py, pz, E, M;
-    if (iss >> ptype >> state >> skip >> skip >> skip >> skip >> px >> py >>
-        pz >> E >> M) {
-      if ((ptype == 11) && (state == -1)) {
-        double ebeam = E;
-        double e_px, e_py, e_pz, a_px, a_py, a_pz, e_E, a_E, e_M, a_M;
-        for (int i = 0; i < 2; i++) {
-          std::getline(ifile, line);
-        }
-        std::istringstream jss(line);
-        jss >> ptype >> state >> skip >> skip >> skip >> skip >> e_px >> e_py >>
-            e_pz >> e_E >> e_M;
-        if ((ptype == 11) && (state == 1)) {  // Find a final state electron.
-          for (int i = 0; i < 2; i++) {
-            std::getline(ifile, line);
-          }
-          std::istringstream kss(line);
-          kss >> ptype >> state >> skip >> skip >> skip >> skip >> a_px >>
-              a_py >> a_pz >> a_E >> a_M;
-          if (ptype == 622 and state == 1) {
-            if (abs(1. - a_M / MA) > 1e-3) {
-              EXCEPTION_RAISE("BadMGEvnt",
-                              "A MadGraph imported event has a different "
-                              "APrime mass than the model has (MadGraph = " +
-                                  std::to_string(a_M) + "GeV; Model = " +
-                                  std::to_string(MA) + "GeV).");
-            }
-            OutgoingKinematics evnt;
-            double cmpx = a_px + e_px;
-            double cmpy = a_py + e_py;
-            double cmpz = a_pz + e_pz;
-            double cmE = a_E + e_E;
-            evnt.electron = TLorentzVector(e_px, e_py, e_pz, e_E);
-            evnt.centerMomentum = TLorentzVector(cmpx, cmpy, cmpz, cmE);
-            evnt.E = ebeam;
-            madGraphData_[ebeam].push_back(evnt);
-          }  // get a prime kinematics
-        }    // check for final state
-      }      // check for particle type and state
-    }        // able to get momentum/energy numbers
-  }          // while getting lines
-  // Add the energy to the list, with a random offset between 0 and the total
-  // number of entries.
-  ifile.close();
-  ldmx_log(info) << "done parsing.";
-}
-
-void DarkBremVertexLibraryModel::MakePlaceholders() {
-  currentDataPoints_.clear();
-  maxIterations_ = 10000;
-  for (const auto &iter : madGraphData_) {
-    currentDataPoints_[iter.first] = int(G4UniformRand() * iter.second.size());
-    if (iter.second.size() < maxIterations_)
-      maxIterations_ = iter.second.size();
-  }
-}
-
-DarkBremVertexLibraryModel::OutgoingKinematics
-DarkBremVertexLibraryModel::GetMadgraphData(double E0) {
-  OutgoingKinematics cmdata;  // data frame to return
-
-  // Cycle through imported beam energies until the closest one above is found,
-  // or the max is reached.
-  double samplingE = 0.;
-  for (const auto &keyVal : currentDataPoints_) {
-    samplingE = keyVal.first;  // move samplingE up
-    // check if went under the sampling energy
-    //  the map is sorted by key, so we can be done right after E0 goes under
-    //  samplingE
-    if (E0 < samplingE) break;
-  }
-  // now samplingE is the closest energy above E0 or the maximum energy imported
-  // from mad graph
-
-  // Need to loop around if we hit the end, when the size of
-  // madGraphData_[samplingE] is smaller than
-  //  the number of events we want
-  if (currentDataPoints_.at(samplingE) >= madGraphData_.at(samplingE).size()) {
-    currentDataPoints_[samplingE] = 0;
-  }
-
-  // Get the lorentz vectors from the index given by the placeholder.
-  cmdata = madGraphData_.at(samplingE).at(currentDataPoints_.at(samplingE));
-
-  // Increment the current index
-  currentDataPoints_[samplingE]++;
-
-  return cmdata;
+  G4DynamicParticle *dphoton = new G4DynamicParticle(G4APrime::APrime(), DMDirection, DMKinE);
+  G4DynamicParticle *el = new G4DynamicParticle(track.GetDefinition(), projDirection,recoilE);
+  particleChange.SetNumberOfSecondaries(2);
+  particleChange.AddSecondary(dphoton);
+  particleChange.AddSecondary(el);
+  particleChange.ProposeTrackStatus(fStopAndKill);
 }
 
 }  // namespace darkbrem

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -57,11 +57,13 @@ ElementXsecCache::key_t ElementXsecCache::computeKey(G4double energy,
 }
 
 const std::string G4eDarkBremsstrahlung::PROCESS_NAME = "eDarkBrem";
+G4eDarkBremsstrahlung* G4eDarkBremsstrahlung::the_process_ = nullptr;
 
 G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
     const framework::config::Parameters& params)
     : G4VDiscreteProcess(G4eDarkBremsstrahlung::PROCESS_NAME,
                          fElectromagnetic) {
+  the_process_ = this;
   // we need to pretend to be an EM process so the biasing framework recognizes
   // us
   SetProcessSubType(63);  // needs to be different from the other Em Subtypes

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -73,6 +73,7 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
   only_one_per_event_ = params.getParameter<bool>("only_one_per_event");
   cache_xsec_ = params.getParameter<bool>("cache_xsec");
   ap_mass_ = params.getParameter<double>("ap_mass");
+  muons_ = params.getParameter<bool>("muons");
 
   auto model{params.getParameter<framework::config::Parameters>("model")};
   auto model_name{model.getParameter<std::string>("name")};
@@ -95,7 +96,8 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
 }
 
 G4bool G4eDarkBremsstrahlung::IsApplicable(const G4ParticleDefinition& p) {
-  return &p == G4Electron::Definition() or &p == G4MuonMinus::Definition() or &p == G4MuonPlus::Definition();
+  if (muons_) return &p == G4MuonMinus::Definition() or &p == G4MuonPlus::Definition();
+  else return &p == G4Electron::Definition();
 }
 
 void G4eDarkBremsstrahlung::PrintInfo() {
@@ -198,6 +200,11 @@ G4double G4eDarkBremsstrahlung::GetMeanFreePath(const G4Track& track, G4double,
     SIGMA += NbOfAtomsPerVolume[i] * element_xsec;
   }
   SIGMA *= global_bias_;
+  /*
+  std::cout << "G4eDBrem : sigma = " << SIGMA 
+    << " initIntLenLeft = " << theInitialNumberOfInteractionLength
+    << " nIntLenLeft = " << theNumberOfInteractionLengthLeft << std::endl;
+    */
   return SIGMA > DBL_MIN ? 1. / SIGMA : DBL_MAX;
 }
 }  // namespace darkbrem

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -14,6 +14,7 @@
 #include "G4ProcessType.hh"   //for type of process
 #include "G4RunManager.hh"    //for VerboseLevel
 #include "SimCore/DarkBrem/DarkBremVertexLibraryModel.h"
+#include "SimCore/DarkBrem/DMG4Model.h"
 #include "SimCore/DarkBrem/G4APrime.h"
 
 namespace simcore {
@@ -72,6 +73,8 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
   auto model_name{model.getParameter<std::string>("name")};
   if (model_name == "vertex_library") {
     model_ = std::make_shared<DarkBremVertexLibraryModel>(model);
+  } else if (model_name == "dmg4") {
+    model_ = std::make_shared<DMG4Model>(model);
   } else {
     EXCEPTION_RAISE("DarkBremModel",
                     "Model named '" + model_name + "' is not known.");

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -9,6 +9,7 @@
 
 #include "Framework/RunHeader.h"
 #include "G4Electron.hh"      //for electron definition
+#include "G4MuonMinus.hh"     //for muon definition
 #include "G4EventManager.hh"  //for EventID number
 #include "G4ProcessTable.hh"  //for deactivating dark brem process
 #include "G4ProcessType.hh"   //for type of process
@@ -90,7 +91,7 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
 }
 
 G4bool G4eDarkBremsstrahlung::IsApplicable(const G4ParticleDefinition& p) {
-  return &p == G4Electron::Electron();
+  return &p == G4Electron::Definition() or &p == G4MuonMinus::Definition();
 }
 
 void G4eDarkBremsstrahlung::PrintInfo() {
@@ -192,7 +193,7 @@ G4double G4eDarkBremsstrahlung::GetMeanFreePath(const G4Track& track, G4double,
 
     SIGMA += NbOfAtomsPerVolume[i] * element_xsec;
   }
-
+  SIGMA *= 1e12;
   return SIGMA > DBL_MIN ? 1. / SIGMA : DBL_MAX;
 }
 }  // namespace darkbrem

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -10,6 +10,7 @@
 #include "Framework/RunHeader.h"
 #include "G4Electron.hh"      //for electron definition
 #include "G4MuonMinus.hh"     //for muon definition
+#include "G4MuonPlus.hh"      //for muon definition
 #include "G4EventManager.hh"  //for EventID number
 #include "G4ProcessTable.hh"  //for deactivating dark brem process
 #include "G4ProcessType.hh"   //for type of process
@@ -63,11 +64,12 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
     const framework::config::Parameters& params)
     : G4VDiscreteProcess(G4eDarkBremsstrahlung::PROCESS_NAME,
                          fElectromagnetic) {
-  the_process_ = this;
   // we need to pretend to be an EM process so the biasing framework recognizes
   // us
+  the_process_ = this;
   SetProcessSubType(63);  // needs to be different from the other Em Subtypes
 
+  global_bias_ = params.getParameter<double>("global_bias");
   only_one_per_event_ = params.getParameter<bool>("only_one_per_event");
   cache_xsec_ = params.getParameter<bool>("cache_xsec");
   ap_mass_ = params.getParameter<double>("ap_mass");
@@ -93,7 +95,7 @@ G4eDarkBremsstrahlung::G4eDarkBremsstrahlung(
 }
 
 G4bool G4eDarkBremsstrahlung::IsApplicable(const G4ParticleDefinition& p) {
-  return &p == G4Electron::Definition() or &p == G4MuonMinus::Definition();
+  return &p == G4Electron::Definition() or &p == G4MuonMinus::Definition() or &p == G4MuonPlus::Definition();
 }
 
 void G4eDarkBremsstrahlung::PrintInfo() {
@@ -195,7 +197,7 @@ G4double G4eDarkBremsstrahlung::GetMeanFreePath(const G4Track& track, G4double,
 
     SIGMA += NbOfAtomsPerVolume[i] * element_xsec;
   }
-  //SIGMA *= 1e12; // muons since biasing don't work
+  SIGMA *= global_bias_;
   return SIGMA > DBL_MIN ? 1. / SIGMA : DBL_MAX;
 }
 }  // namespace darkbrem

--- a/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
+++ b/src/SimCore/DarkBrem/G4eDarkBremsstrahlung.cxx
@@ -195,7 +195,7 @@ G4double G4eDarkBremsstrahlung::GetMeanFreePath(const G4Track& track, G4double,
 
     SIGMA += NbOfAtomsPerVolume[i] * element_xsec;
   }
-  SIGMA *= 1e12;
+  //SIGMA *= 1e12; // muons since biasing don't work
   return SIGMA > DBL_MIN ? 1. / SIGMA : DBL_MAX;
 }
 }  // namespace darkbrem

--- a/src/SimCore/Persist/RootPersistencyManager.cxx
+++ b/src/SimCore/Persist/RootPersistencyManager.cxx
@@ -124,9 +124,11 @@ void RootPersistencyManager::writeHitsCollections(
     const G4Event *anEvent, framework::Event *outputEvent) {
   // Get the HC of this event.
   G4HCofThisEvent *hce = anEvent->GetHCofThisEvent();
-  int nColl = hce->GetNumberOfCollections();
+  // check for no hit collections for this event
+  if (!hce) return;
 
   // Loop over all hits collections.
+  int nColl = hce->GetNumberOfCollections();
   for (int iColl = 0; iColl < nColl; iColl++) {
     // Get a hits collection and its name.
     G4VHitsCollection *hc = hce->GetHC(iColl);

--- a/src/SimCore/Persist/RootPersistencyManager.cxx
+++ b/src/SimCore/Persist/RootPersistencyManager.cxx
@@ -7,11 +7,6 @@
 #include <algorithm>
 #include <memory>
 
-/*~~~~~~~~~~~*/
-/*   Event   */
-/*~~~~~~~~~~~*/
-#include "Recon/Event/EventConstants.h"
-
 /*~~~~~~~~~~~~~~~*/
 /*   Framework   */
 /*~~~~~~~~~~~~~~~*/
@@ -154,7 +149,7 @@ void RootPersistencyManager::writeHitsCollections(
       G4CalorimeterHitsCollection *calHitsColl =
           dynamic_cast<G4CalorimeterHitsCollection *>(hc);
       std::vector<ldmx::SimCalorimeterHit> outputColl;
-      if (collName == ldmx::EventConstants::ECAL_SIM_HITS) {
+      if (collName == "EcalSimHits") {
         // Write ECal G4CalorimeterHit collection to output SimCalorimeterHit
         // collection using helper class.
         ecalHitIO_.writeHitsCollection(calHitsColl, outputColl);

--- a/src/SimCore/RootSimFromEcalSP.cxx
+++ b/src/SimCore/RootSimFromEcalSP.cxx
@@ -26,7 +26,6 @@
 //   ldmx-sw   //
 //-------------//
 #include "Framework/Configure/Parameters.h"
-#include "Recon/Event/EventConstants.h"
 #include "SimCore/Event/SimTrackerHit.h"
 
 namespace simcore {

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -143,6 +143,8 @@ void RunManager::Initialize() {
   for (const auto& [key, act] : actions) {
     std::visit([this](auto&& arg) { this->SetUserAction(arg); }, act);
   }
+  G4Electron::Definition()->GetProcessManager()->DumpInfo();
+  G4MuonMinus::Definition()->GetProcessManager()->DumpInfo();
 }
 
 void RunManager::TerminateOneEvent() {
@@ -164,8 +166,8 @@ void RunManager::TerminateOneEvent() {
   std::vector<G4String> dark_brem_processes = {
       darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME,
       "biasWrapper(" + darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME + ")"};
-  ptable->SetVerboseLevel(
-      0);  // silent ptable while searching for process that may/may not exist
+  // silent ptable while searching for process that may/may not exist
+  ptable->SetVerboseLevel(0);
   for (auto const& name : dark_brem_processes)
     ptable->SetProcessActivation(name, true);
   ptable->SetVerboseLevel(verbosity);

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -88,8 +88,13 @@ void RunManager::setupPhysics() {
     for (const simcore::XsecBiasingOperator* bop :
          simcore::PluginFactory::getInstance().getBiasingOperators()) {
       std::cout << "[ RunManager ]: Biasing operator '" << bop->GetName()
-                << "' set to bias " << bop->getParticleToBias() << std::endl;
+                << "' set to bias '" << bop->getParticleToBias() << "'" << std::endl;
       biasingPhysics->Bias(bop->getParticleToBias());
+      if (bop->getParticleToBias() == "mu-") {
+        std::cout << "[ RunManager ]: Biasing operator '" << bop->GetName()
+                  << "' set to bias 'mu+'" << std::endl;
+        biasingPhysics->Bias("mu+");
+      }
     }
 
     // Register the physics constructor to the physics list:

--- a/src/SimCore/Simulator.cxx
+++ b/src/SimCore/Simulator.cxx
@@ -178,29 +178,9 @@ void Simulator::beforeNewRun(ldmx::RunHeader& header) {
     bop->RecordConfig(header);
   }
 
-  auto dark_brem{
-      parameters_.getParameter<framework::config::Parameters>("dark_brem")};
-  if (dark_brem.getParameter<bool>("enable")) {
-    // the dark brem process is enabled, find it and then record its
-    // configuration
-    G4ProcessVector* candidates = G4ProcessTable::GetProcessTable()->FindProcesses(
-        darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME);
-    int n_processes = candidates->size();
-    for (int i_process = 0; i_process < n_processes; i_process++) {
-      G4VProcess* process = (*candidates)[i_process];
-      if (process->GetProcessName().contains(
-              darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME)) {
-        // reset process to wrapped process if it is biased
-        if (dynamic_cast<G4BiasingProcessInterface*>(process))
-          process = dynamic_cast<G4BiasingProcessInterface*>(process)
-                        ->GetWrappedProcess();
-        // record the process configuration to the run header
-        dynamic_cast<darkbrem::G4eDarkBremsstrahlung*>(process)
-          ->RecordConfig(header);
-        break;
-      }  // this process is the dark brem process
-    }    // loop through electron processes
-  }      // dark brem has been enabled
+  if (darkbrem::G4eDarkBremsstrahlung::Get()) {
+    darkbrem::G4eDarkBremsstrahlung::Get()->RecordConfig(header);
+  }
 
   auto generators{
       parameters_.getParameter<std::vector<framework::config::Parameters>>(

--- a/src/SimCore/Simulator.cxx
+++ b/src/SimCore/Simulator.cxx
@@ -23,6 +23,7 @@
 /*~~~~~~~~~~~~~~*/
 #include "G4CascadeParameters.hh"
 #include "G4Electron.hh"
+#include "G4ProcessTable.hh"
 #include "G4GDMLParser.hh"
 #include "G4GeometryManager.hh"
 #include "G4UImanager.hh"
@@ -182,11 +183,11 @@ void Simulator::beforeNewRun(ldmx::RunHeader& header) {
   if (dark_brem.getParameter<bool>("enable")) {
     // the dark brem process is enabled, find it and then record its
     // configuration
-    G4ProcessVector* electron_processes =
-        G4Electron::Electron()->GetProcessManager()->GetProcessList();
-    int n_electron_processes = electron_processes->size();
-    for (int i_process = 0; i_process < n_electron_processes; i_process++) {
-      G4VProcess* process = (*electron_processes)[i_process];
+    G4ProcessVector* candidates = G4ProcessTable::GetProcessTable()->FindProcesses(
+        darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME);
+    int n_processes = candidates->size();
+    for (int i_process = 0; i_process < n_processes; i_process++) {
+      G4VProcess* process = (*candidates)[i_process];
       if (process->GetProcessName().contains(
               darkbrem::G4eDarkBremsstrahlung::PROCESS_NAME)) {
         // reset process to wrapped process if it is biased
@@ -194,8 +195,8 @@ void Simulator::beforeNewRun(ldmx::RunHeader& header) {
           process = dynamic_cast<G4BiasingProcessInterface*>(process)
                         ->GetWrappedProcess();
         // record the process configuration to the run header
-        dynamic_cast<darkbrem::G4eDarkBremsstrahlung*>(process)->RecordConfig(
-            header);
+        dynamic_cast<darkbrem::G4eDarkBremsstrahlung*>(process)
+          ->RecordConfig(header);
         break;
       }  // this process is the dark brem process
     }    // loop through electron processes

--- a/src/SimCore/XsecBiasingOperator.cxx
+++ b/src/SimCore/XsecBiasingOperator.cxx
@@ -3,6 +3,8 @@
 #include "Framework/Exception/Exception.h"
 #include "SimCore/PluginFactory.h"
 
+#include "G4MuonMinus.hh"
+
 namespace simcore {
 
 XsecBiasingOperator::XsecBiasingOperator(
@@ -16,6 +18,8 @@ void XsecBiasingOperator::StartRun() {
     processManager_ = G4Gamma::GammaDefinition()->GetProcessManager();
   } else if (this->getParticleToBias().compare("e-") == 0) {
     processManager_ = G4Electron::ElectronDefinition()->GetProcessManager();
+  } else if (this->getParticleToBias().compare("mu-") == 0) {
+    processManager_ = G4MuonMinus::Definition()->GetProcessManager();
   } else if (this->getParticleToBias().compare("neutron") == 0) {
     processManager_ = G4Neutron::NeutronDefinition()->GetProcessManager();
   } else if (this->getParticleToBias().compare("kaon0L") == 0) {
@@ -26,7 +30,7 @@ void XsecBiasingOperator::StartRun() {
   }
 
   std::cout << "[ XsecBiasingOperator ]: Biasing particles of type "
-            << this->getParticleToBias() << std::endl;
+            << processManager_->GetParticleType()->GetParticleName() << std::endl;
 
   if (processIsBiased(this->getProcessToBias())) {
     xsecOperation_ =


### PR DESCRIPTION
In order to compare our dark brem model with [NA64's DMG4](https://arxiv.org/abs/2101.12192v1), I have introduced another model for the dark brem process so that the user can choose to run the "library" model or the "DMG4" model.

As a side benefit, I also added a patch so that the simulation can run without any hit collections being generated. Helpful for studying how the dark brem process behaves in simple materials.

Currently, this is pretty stale and will require some rebasing, so I have marked this as a draft.

- [ ] Make DMG4 an optional dependency (i.e. don't compile the model if it is not around)
- [ ] DMG4 requires gsl, not sure how to handle this, right now that means we are limited to using ldmx/dev:v2.0
- [ ] Update to SimCore/trunk and ldmx-sw/trunk
- [ ] Document usage of DMG4 model