### PR TITLE
Update Run number documentation

### DIFF
--- a/python/examples.py.in
+++ b/python/examples.py.in
@@ -24,7 +24,9 @@ def inclusive_single_e() :
 
     sim = simulator.simulator( "inclusive_single_e" )
     sim.setDetector( "ldmx-det-v12" )
-    sim.runNumber = 1
+    # Note: This example used to set the runNumber parameter for the simulator.
+    # The run number is managed by the process object directly so setting it for
+    # the simulator no longer does anything
     sim.description = "One 4GeV electron shot from far upstream."
     sim.generators.append(generators.single_4gev_e_upstream_tagger())
     return sim
@@ -55,7 +57,9 @@ def lheExample( lheFile ) :
 
     sim = simulator.simulator( "lheSimulation" )
     sim.setDetector( "ldmx-det-v12" )
-    sim.runNumber = 1
+    # Note: This example used to set the runNumber parameter for the simulator.
+    # The run number is managed by the process object directly so setting it for
+    # the simulator no longer does anything
     sim.description = "Example of how to use LHE generator"
     sim.generators.append(generators.lhe( "LHEExample" , lheFile ))
     return sim
@@ -83,7 +87,9 @@ def gpsExample( ) :
 
     sim = simulator.simulator( "gpsExample" )
     sim.setDetector( "ldmx-det-v12" )
-    sim.runNumber = 1
+    # Note: This example used to set the runNumber parameter for the simulator.
+    # The run number is managed by the process object directly so setting it for
+    # the simulator no longer does anything
     sim.description = "Example of how to use GPS generator"
     gpsGen = generators.gps( "GPSExample" , [
         "/gps/particle e-",
@@ -123,7 +129,9 @@ def multiExample( ) :
 
     sim = ldmxcfg.Producer( "mpgExample" , "simcore::Simulator" )
     sim.setDetector( "ldmx-det-v12" )
-    sim.runNumber = 1
+    # Note: This example used to set the runNumber parameter for the simulator.
+    # The run number is managed by the process object directly so setting it for
+    # the simulator no longer does anything
     sim.description = "Example of how to use MPG generator"
     mpgGen = generators.multi( "MPGExample" )
     mpgGen.vertex = [ 0., 0., 0. ] #mm

--- a/src/SimCore/Simulator.cxx
+++ b/src/SimCore/Simulator.cxx
@@ -69,6 +69,16 @@ void Simulator::configure(framework::config::Parameters& parameters) {
   // Set the verbosity level.  The default level  is 0.
   verbosity_ = parameters_.getParameter<int>("verbosity");
 
+  // in past versions of SimCore, the run number for the simulation was
+  // passed directly to the simulator class rather than pulled from central
+  // framework. This is here to prevent the user from accidentally using the
+  // old style.
+  if (parameters.exists("runNumber")) {
+    EXCEPTION_RAISE("InvalidParam",
+      "Remove old-style of setting the simulation run number (sim.runNumber)."
+      " Replace with using the Process object (p.run).");
+  }
+
   // If the verbosity level is set to 0,
   // If the verbosity level is > 1, log everything to a file. Otherwise,
   // dump the output. If a prefix has been specified, append it ot the

--- a/test/basic.py
+++ b/test/basic.py
@@ -6,10 +6,11 @@ import sys
 p.maxEvents = 10
 if len(sys.argv) > 1 :
     p.maxEvents = int(sys.argv[1])
-p.run = 9001
 # we want to see every event
 p.logFrequency = 1
 p.termLogLevel = 0
+# Set a run number
+p.run = 9001
 # we also only have an output file
 p.outputFiles = [ "justSim_" + str(p.maxEvents) + "_events.root" ]
 from LDMX.SimCore import simulator as sim


### PR DESCRIPTION
- Remove run numbers from examples
- Update basic.py test
- add exception for if old method of run number setting is used

This resolves #62 and was orignally developed (and noticed) by @EinarElen.
