### PR TITLE
Iss69

### DIFF
--- a/include/SimCore/SDs/HcalSD.h
+++ b/include/SimCore/SDs/HcalSD.h
@@ -55,7 +55,7 @@ class HcalSD : public SensitiveDetector {
                           }) != std::end(gdmlIdentifiers_);
     }
     return false;
-  }  // namespace simcore
+  }
 
   /**
    * Create a hit out of the energy deposition deposited during a

--- a/include/SimCore/SDs/HcalSD.h
+++ b/include/SimCore/SDs/HcalSD.h
@@ -4,9 +4,13 @@
 /*~~~~~~~~~~~~~~*/
 /*   DetDescr   */
 /*~~~~~~~~~~~~~~*/
-#include "SimCore/SensitiveDetector.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
 #include "SimCore/Event/SimCalorimeterHit.h"
 #include "SimCore/G4User/TrackingAction.h"
+#include "SimCore/SensitiveDetector.h"
 #include "SimCore/TrackMap.h"
 
 namespace simcore {
@@ -41,10 +45,15 @@ class HcalSD : public SensitiveDetector {
   bool isSensDet(G4LogicalVolume* volume) const final override {
     auto region = volume->GetRegion();
     if (region and region->GetName().contains("CalorimeterRegion")) {
-      return volume->GetName().contains("ScintBox");
+      const auto name{volume->GetName()};
+      return std::find_if(std::begin(gdmlIdentifiers_),
+                          std::end(gdmlIdentifiers_),
+                          [&name](const auto& identifier) {
+                            return name.contains(identifier);
+                          }) != std::end(gdmlIdentifiers_);
     }
     return false;
-  }
+  }  // namespace simcore
 
   /**
    * Create a hit out of the energy deposition deposited during a
@@ -75,7 +84,6 @@ class HcalSD : public SensitiveDetector {
 
   // collection of hits to write to event bus
   std::vector<ldmx::SimCalorimeterHit> hits_;
-
 };  // HcalSD
 
 }  // namespace simcore

--- a/include/SimCore/SDs/HcalSD.h
+++ b/include/SimCore/SDs/HcalSD.h
@@ -40,7 +40,9 @@ class HcalSD : public SensitiveDetector {
    * Check if the input logical volume is a part of the hcal sensitive
    * volumes.
    *
-   * @note Depends on the volume names defined in the GDML!
+   * @note This will match if a) the volume has the auxiliary tag "Region" set
+   * to contain to "CalorimeterRegion" and b) the volume name contains one of
+   * the identifiers in the gdml_identifiers parameter
    */
   bool isSensDet(G4LogicalVolume* volume) const final override {
     auto region = volume->GetRegion();
@@ -75,6 +77,11 @@ class HcalSD : public SensitiveDetector {
   virtual void EndOfEvent() final override { hits_.clear(); }
 
  private:
+  // A list of identifiers used to find out whether or not a given logical
+  // volume is one of the Hcal sensitive detector volumes. Any volume that is
+  // part of the CalorimeterRegion region and has a name which contains at least
+  // one of the identifiers in here will be considered a sensitive detector in
+  // the Hcal.
   std::vector<std::string> gdmlIdentifiers_;
   // TODO: document!
   double birksc1_;

--- a/include/SimCore/SDs/HcalSD.h
+++ b/include/SimCore/SDs/HcalSD.h
@@ -63,11 +63,10 @@ class HcalSD : public SensitiveDetector {
     event.add(COLLECTION_NAME, hits_);
   }
 
-  virtual void EndOfEvent() final override {
-    hits_.clear();
-  }
+  virtual void EndOfEvent() final override { hits_.clear(); }
 
  private:
+  std::vector<std::string> gdmlIdentifiers_;
   // TODO: document!
   double birksc1_;
 

--- a/python/sensitive_detectors.py
+++ b/python/sensitive_detectors.py
@@ -65,8 +65,16 @@ class HcalSD(simcfg.SensitiveDetector) :
     """SD for the HCal
 
     Separate from the other calorimeters since it includes a Birks law
-    estimate. No other parameters
-    
+    estimate.
+
+    Parameters
+    ----------
+    gdml_identifiers : list[str]
+
+        A list of strings used to determine which volumes in the Hcal are
+        considered sensitive. Any volume name containing at least one of these
+        identifiers will have a sensitive detector attached.
+
     """
     def __init__(self, gdml_identifiers = ['ScintBox', 'scint_box']) :
         super().__init__('hcal_sd', 'simcore::HcalSD','SimCore_SDs')

--- a/python/sensitive_detectors.py
+++ b/python/sensitive_detectors.py
@@ -68,8 +68,9 @@ class HcalSD(simcfg.SensitiveDetector) :
     estimate. No other parameters
     
     """
-    def __init__(self) :
+    def __init__(self, gdml_identifiers = ['ScintBox', 'scint_box']) :
         super().__init__('hcal_sd', 'simcore::HcalSD','SimCore_SDs')
+        self.gdml_identifiers = gdml_identifiers
 
 class EcalSD(simcfg.SensitiveDetector) :
     """SD for the ECal

--- a/python/sensitive_detectors.py
+++ b/python/sensitive_detectors.py
@@ -75,6 +75,9 @@ class HcalSD(simcfg.SensitiveDetector) :
         considered sensitive. Any volume name containing at least one of these
         identifiers will have a sensitive detector attached.
 
+        The current defaults match the mainline LDMX Hcal (ScintBox) and
+        prototype Hcal (scint_box) scintillator geometries.
+
     """
     def __init__(self, gdml_identifiers = ['ScintBox', 'scint_box']) :
         super().__init__('hcal_sd', 'simcore::HcalSD','SimCore_SDs')

--- a/src/SimCore/Geo/AuxInfoReader.cxx
+++ b/src/SimCore/Geo/AuxInfoReader.cxx
@@ -46,7 +46,10 @@ void AuxInfoReader::readGlobalAuxInfo() {
     G4String auxUnit = iaux->unit;
 
     if (auxType == "SensDet") {
-      std::cerr << "[ WARN ] : Not defining SensDet in GDML anymore." << std::endl;
+      std::cerr
+          << "[ WARN ] : Not defining SensDet in GDML since v1.0 of SimCore. "
+             "See https://github.com/LDMX-Software/SimCore/issues/39"
+          << std::endl;
     } else if (auxType == "MagneticField") {
       createMagneticField(auxVal, iaux->auxList);
     } else if (auxType == "Region") {

--- a/src/SimCore/SDs/HcalSD.cxx
+++ b/src/SimCore/SDs/HcalSD.cxx
@@ -3,8 +3,8 @@
 /*~~~~~~~~~~~~~~*/
 /*   DetDescr   */
 /*~~~~~~~~~~~~~~*/
-#include "DetDescr/HcalID.h"
 #include "DetDescr/HcalGeometry.h"
+#include "DetDescr/HcalID.h"
 
 // STL
 #include <iostream>
@@ -16,17 +16,19 @@
 #include "G4StepPoint.hh"
 
 namespace simcore {
- 
+
 const std::string HcalSD::COLLECTION_NAME = "HcalSimHits";
 
 HcalSD::HcalSD(const std::string& name, simcore::ConditionsInterface& ci,
                const framework::config::Parameters& p)
-    : SensitiveDetector(name, ci, p), birksc1_(1.29e-2), birksc2_(9.59e-6) {}
+    : SensitiveDetector(name, ci, p), birksc1_(1.29e-2), birksc2_(9.59e-6) {
+  gdmlIdentifiers_ = {
+      p.getParameter<std::vector<std::string>>("gdml_identifiers")};
+}
 
 HcalSD::~HcalSD() {}
 
 G4bool HcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist) {
-
   // Get the edep from the step.
   G4double edep = aStep->GetTotalEnergyDeposit();
 
@@ -66,7 +68,6 @@ G4bool HcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist) {
   //              we have to divide the energy deposit in MeV by the
   //              product of the step length (in cm) and the density
   //              of the scintillator:
-
 
   G4double birksFactor(1.0);
   G4double stepLength = aStep->GetStepLength() / CLHEP::cm;


### PR DESCRIPTION
 This PR updates `HcalSD` to make the check in `isSensDet(G4LogicalVolume* volume)` check for a configurable list of identifiers rather than a single hard-coded `ScintBox`. This is sufficient to make simulations with the prototype geometry work. I'm not sure if we would want to add anything similar for other subsystems later, but that would be straight forward to do. I've tested this with both v13 and the prototype geometries and both are registering SimHits. 