### PR TITLE
primary patch and debug helpers

### DIFF
--- a/include/SimCore/Geo/GDMLParser.h
+++ b/include/SimCore/Geo/GDMLParser.h
@@ -75,8 +75,11 @@ class GDMLParser : public Parser {
   /// The auxiliary info reader
   std::unique_ptr<simcore::geo::AuxInfoReader> info_;
 
-  /// The parameters used to configure this parser
-  framework::config::Parameters parameters_;
+  /// path to the detector GDML
+  std::string detector_;
+
+  /// should we take the time to validate
+  bool validate_;
 
   /// The name of the parsed detector
   std::string detector_name_{""};

--- a/include/SimCore/SDs/TrigScintSD.h
+++ b/include/SimCore/SDs/TrigScintSD.h
@@ -41,7 +41,7 @@ class TrigScintSD : public SensitiveDetector {
    * @param[in] step The step information.
    * @param[in] history The readout history.
    */
-  G4bool ProcessHits(G4Step* step, G4TouchableHistory* history);
+  G4bool ProcessHits(G4Step* step, G4TouchableHistory* history) final override;
 
   /**
    * Save our hits collection into the event bus and reset it.

--- a/python/generators.py.in
+++ b/python/generators.py.in
@@ -215,7 +215,7 @@ def single_4gev_e_upstream_tagger() :
     particle_gun.particle = 'e-'
     particle_gun.position = [ -27.926 , 0 , -800 ] # mm
     import math
-    theta = math.radians(4.5)
+    theta = math.radians(5.65)
     particle_gun.direction = [ math.sin(theta) , 0, math.cos(theta) ] #unitless
     particle_gun.energy = 4.0 # GeV
 

--- a/python/simulator.py.in
+++ b/python/simulator.py.in
@@ -111,10 +111,10 @@ class simulator(Producer):
                 sds.TrackerSD.recoil(),
                 sds.HcalSD(),
                 sds.EcalSD(),
-                #sds.TrigScintSD.up(),
+                sds.TrigScintSD.up(),
                 sds.TrigScintSD.down(),
                 sds.TrigScintSD.tag(),
-                #sds.TrigScintSD.target()
+                sds.TrigScintSD.target()
                 ]
         if include_scoring_planes :
             self.scoringPlanes = mP.makeScoringPlanesPath( det_name )

--- a/src/SimCore/Geo/GDMLParser.cxx
+++ b/src/SimCore/Geo/GDMLParser.cxx
@@ -5,10 +5,12 @@ namespace geo {
 
 GDMLParser::GDMLParser(framework::config::Parameters &parameters,
                        simcore::ConditionsInterface &ci) {
+  detector_ = parameters.getParameter<std::string>("detector");
+  validate_ = parameters.getParameter<bool>("validate_detector");
   parser_ = std::make_unique<G4GDMLParser>();
+  parser_->SetOverlapCheck(validate_);
   info_ =
       std::make_unique<simcore::geo::AuxInfoReader>(parser_.get(), parameters);
-  parameters_ = parameters;
 }
 
 G4VPhysicalVolume *GDMLParser::GetWorldVolume() {
@@ -16,8 +18,7 @@ G4VPhysicalVolume *GDMLParser::GetWorldVolume() {
 }
 
 void GDMLParser::read() {
-  parser_->Read(parameters_.getParameter<std::string>("detector"),
-                parameters_.getParameter<bool>("validate_detector"));
+  parser_->Read(detector_, validate_);
   info_->readGlobalAuxInfo();
   info_->assignAuxInfoToVolumes();
   detector_name_ = info_->getDetectorHeader()->getName();


### PR DESCRIPTION
- update angle of initial primary so it goes through center of target (actually)
- enable target area sim hits by un-commenting their SDs
- add `final override` keywords to SD ProcessHits to make sure it is declared properly
- add in overlap checking when a user wants to validate the geometry