### PR TITLE
modify volume names for attaching to ecal volumes during biasing

### DIFF
--- a/src/SimCore/DetectorConstruction.cxx
+++ b/src/SimCore/DetectorConstruction.cxx
@@ -23,9 +23,10 @@ namespace logical_volume_tests {
 static bool isInEcal(G4LogicalVolume* vol, const std::string& vol_to_bias) {
   G4String volumeName = vol->GetName();
   return ((volumeName.contains("Si") || volumeName.contains("W") ||
-           volumeName.contains("PCB") || volumeName.contains("CFMix") ||
-           volumeName.contains("Al")) &&
-          volumeName.contains("volume"));
+           volumeName.contains("PCB") || volumeName.contains("strongback") ||
+           volumeName.contains("Glue") || volumeName.contains("CFMix") ||
+           volumeName.contains("Al") || volumeName.contains("C")
+          ) && volumeName.contains("volume"));
 }
 
 /**

--- a/src/SimCore/DetectorConstruction.cxx
+++ b/src/SimCore/DetectorConstruction.cxx
@@ -39,9 +39,8 @@ static bool isInEcal(G4LogicalVolume* vol, const std::string& vol_to_bias) {
  */
 static bool isInHcal(G4LogicalVolume* vol, const std::string& vol_to_bias) {
   G4String volumeName = vol->GetName();
-  return ((volumeName.contains("abso2") || volumeName.contains("abso3") ||
-           volumeName.contains("ScintBox") || volumeName.contains("absoBox")) &&
-          volumeName.contains("volume"));
+  return ((volumeName.contains("abso") || volumeName.contains("ScintBox") || volumeName.contains("scint")) 
+          && volumeName.contains("hcal") && volumeName.contains("olume"));
 }
 
 /**


### PR DESCRIPTION
We changed the names of some of the ECal volumes in the GDML for readability, we need to update those names in the biasing attachment (similar to how SDs are attached).

### To Do
- [x] Verify that the biasing operators are being attached correctly in the ECal for _both_ v12 and v14
- [x] Check the other subsystems for name updates as well
- [x] Look into investigating LV parent tree? That would allow us to change the names more freely...