### PR TITLE
fixup string manipulation for scoring planes

### DIFF
--- a/python/sensitive_detectors.py
+++ b/python/sensitive_detectors.py
@@ -12,13 +12,15 @@ class ScoringPlaneSD(simcfg.SensitiveDetector) :
     ----------
     subsystem : str
         Name of subsystem to store scoring plane hits for
-        Names must match what is in gdml for <subsystem>_sp
+        Names must match what is in gdml for sp_<subsystem>
     """
     def __init__(self,subsystem) :
         super().__init__(f'{subsystem}_sp','simcore::ScoringPlaneSD','SimCore_SDs')
 
-        self.collection_name = f'{subsystem.capitalize()}ScoringPlaneHits'
-        self.match_substr = f'sp_{subsystem.lower()}' #depends on gdml
+        # we don't use the Python built-in str.capitalize since
+        #  that function changes all characters after the first one to lowercase
+        self.collection_name = f'{subsystem[0].upper()+subsystem[1:]}ScoringPlaneHits'
+        self.match_substr = f'sp_{subsystem}' #depends on gdml
 
     def ecal() :
         return ScoringPlaneSD('ecal')


### PR DESCRIPTION
We do two things with the input subsystem name:
1. We capitalize the first letter and then append 'ScoringPlaneHits' to
be the collection name
2. We prepend 'sp_' to be the match substring for logical volumes

This means the input subsystem is the name of the scoring planes in the
GDML with the 'sp_' prefix removed.
