### PR TITLE
Factor out rotations to hcal geometry condition

### DIFF
--- a/src/SimCore/SDs/HcalSD.cxx
+++ b/src/SimCore/SDs/HcalSD.cxx
@@ -44,7 +44,7 @@ ldmx::HcalID HcalSD::decodeCopyNumber(const std::uint32_t copyNumber,
     
     // 5cm wide bars are HARD-CODED
     if (section == ldmx::HcalID::BACK) {
-      if (geometry.layerIsHorizontal(layer)) {
+      if (geometry.backLayerIsHorizontal(layer)) {
         stripID = int((localPosition.y() + scint->GetYHalfLength()) / 50.0);
       } else {
         stripID = int((localPosition.x() + scint->GetXHalfLength()) / 50.0);

--- a/src/SimCore/SDs/HcalSD.cxx
+++ b/src/SimCore/SDs/HcalSD.cxx
@@ -169,75 +169,34 @@ G4bool HcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist) {
   // Convert back to mm
   hit.setPathLength(stepLength * CLHEP::cm / CLHEP::mm);
   hit.setVelocity(track->GetVelocity());
-  // Convert pre/post step position from global coordinates to coordinates within the
-  // scintillator bar
-  const auto localPreStepPoint{topTransform.TransformPoint(prePoint->GetPosition())};
-  const auto localPostStepPoint{topTransform.TransformPoint(postPoint->GetPosition())};
-
-  /**
-   * topTransform translates to the local bar but does not do the rotation
-   * (this is because we don't do a rotation when placing the bars in the GDML)
-   *
-   * the logic below does the rotation to the local coordiates where 
-   *  x : short transverse side of bar
-   *  y : long transverse side of bar
-   *  z : along length of bar
-   *
-   * a lot of this logic could (and should) probably be moved into the geometry
-   * condition for the HCal so that it is more easily maintainable
-   *
-   * @note This logic only applies to the v14 and prototype detector; however,
-   * support for v12 is not broken because no studies using these pre/post step
-   * positions have been (or should be) done with the v12 detector.
-   */
-  const auto& geometry = getCondition<ldmx::HcalGeometry>(
+  const auto &geometry = getCondition<ldmx::HcalGeometry>(
       ldmx::HcalGeometry::CONDITIONS_OBJECT_NAME);
-  switch (id.getSection()) {
-    case ldmx::HcalID::BACK   : 
-      if (geometry.layerIsHorizontal(id.layer())) {
-        hit.setPreStepPosition(localPreStepPoint[2], localPreStepPoint[1], localPreStepPoint[0]);
-        hit.setPostStepPosition(localPostStepPoint[2], localPostStepPoint[1], localPostStepPoint[0]);
-      } else {
-        hit.setPreStepPosition(localPreStepPoint[2], localPreStepPoint[0], localPreStepPoint[1]);
-        hit.setPostStepPosition(localPostStepPoint[2], localPostStepPoint[0], localPostStepPoint[1]);
-      }
-      break;
-    case ldmx::HcalID::TOP    :
-    case ldmx::HcalID::BOTTOM : 
-      if (id.layer() % 2 == 0) {
-        hit.setPreStepPosition(localPreStepPoint[1], localPreStepPoint[2], localPreStepPoint[0]);
-        hit.setPostStepPosition(localPostStepPoint[1], localPostStepPoint[2], localPostStepPoint[0]);
-      } else {
-        hit.setPreStepPosition(localPreStepPoint[1], localPreStepPoint[0], localPreStepPoint[2]);
-        hit.setPostStepPosition(localPostStepPoint[1], localPostStepPoint[0], localPostStepPoint[2]);
-      }
-      break;
-    case ldmx::HcalID::RIGHT  : 
-    case ldmx::HcalID::LEFT   : 
-      if (id.layer() % 2 == 0) {
-        hit.setPreStepPosition(localPreStepPoint[0], localPreStepPoint[2], localPreStepPoint[1]);
-        hit.setPostStepPosition(localPostStepPoint[0], localPostStepPoint[2], localPostStepPoint[1]);
-      } else {
-        hit.setPreStepPosition(localPreStepPoint[0], localPreStepPoint[1], localPreStepPoint[2]);
-        hit.setPostStepPosition(localPostStepPoint[0], localPostStepPoint[1], localPostStepPoint[2]);
-      }
-      break;
-    default : 
-      EXCEPTION_RAISE("HcalSDHit","Found an unknown HCal section");
-  }
+  // Convert pre/post step position from global coordinates to coordinates
+  // within the scintillator bar
+  const auto localPreStepPoint{
+      topTransform.TransformPoint(prePoint->GetPosition())};
+  const auto localPostStepPoint{
+      topTransform.TransformPoint(postPoint->GetPosition())};
+
+  // And rotate them to a local coordinate system for the bar that always has
+  // the same x/y/z definitions (see HcalGeometry for details)
+  auto localPrePositionRotated{geometry.rotateGlobalToLocalBarPosition(
+      {localPreStepPoint[0], localPreStepPoint[1], localPreStepPoint[2]}, id)};
+
+  auto localPostPositionRotated{geometry.rotateGlobalToLocalBarPosition(
+      {localPostStepPoint[0], localPostStepPoint[1], localPostStepPoint[2]},
+      id)};
+  hit.setPreStepPosition(localPrePositionRotated[0], localPrePositionRotated[1],
+                         localPrePositionRotated[2]);
+  hit.setPostStepPosition(localPostPositionRotated[0],
+                          localPostPositionRotated[1],
+                          localPostPositionRotated[2]);
   hit.setPreStepTime(prePoint->GetGlobalTime());
   hit.setPostStepTime(postPoint->GetGlobalTime());
 
-  // do we want to set the hit coordinate in the middle of the absorber?
-  // G4ThreeVector volumePosition =
-  // aStep->GetPreStepPoint()->GetTouchableHandle()->GetHistory()->GetTopTransform().Inverse().TransformPoint(G4ThreeVector());
-  // if (section==ldmx::HcalID::BACK) hit->setPosition(position[0], position[1],
-  // volumePosition.z()); elseif (section==ldmx::HcalID::TOP ||
-  // section==ldmx::HcalID::BOTTOM) hit->setPosition(position[0], volumePosition.y(),
-  // position[2]); elseif (section==ldmx::HcalID::LEFT || section==ldmx::HcalID::RIGHT)
-  // hit->setPosition(volumePosition.x(),position[1] , position[2]);
-
-  if (this->verboseLevel > 2) { hit.Print(); }
+  if (this->verboseLevel > 2) {
+    hit.Print();
+  }
 
   return true;
 }


### PR DESCRIPTION
This resolves #91. We switch to using the hcal geometry condition to determine how to rotate pre/post steps into local coordinates. 

Note: 
This _does_ change the behaviour for earlier Hcal geometries since the rotation will now be done correctly. This doesn't matter since we do not (and do not intend to) use the pre&post step information for these geometries.  