### PR TITLE
G4DarkBreM update and EaT-related Patches

### DIFF
--- a/include/SimCore/UserEventInformation.h
+++ b/include/SimCore/UserEventInformation.h
@@ -25,6 +25,19 @@ class UserEventInformation : public G4VUserEventInformation {
   void decBremCandidateCount() { bremCandidateCount_ -= 1; }
 
   /**
+   * Set the elemental Z in which the dark brem ocurred
+   *
+   * @param[in] z elemental z in which the dark brem ocurred
+   */
+  void setDarkBremMaterialZ(double z) {
+    db_material_z_ = z;
+  }
+
+  double getDarkBremMaterialZ() const {
+    return db_material_z_;
+  }
+
+  /**
    * Set the event weight.
    *
    * @param[in] weight the event weight
@@ -140,6 +153,11 @@ class UserEventInformation : public G4VUserEventInformation {
    * Was the most recent step a electron-nuclear interaction?
    */
   bool last_step_en_{false};
+
+  /**
+   * elemental z in which dark brem occurred (-1 if didn't happen)
+   */
+  double db_material_z_{-1.};
 };
 }  // namespace simcore
 

--- a/include/SimCore/UserEventInformation.h
+++ b/include/SimCore/UserEventInformation.h
@@ -25,12 +25,20 @@ class UserEventInformation : public G4VUserEventInformation {
   void decBremCandidateCount() { bremCandidateCount_ -= 1; }
 
   /**
-   * Set the elemental Z in which the dark brem ocurred
+   * Set the Z of the element in which the dark brem ocurred
    *
-   * @param[in] z elemental z in which the dark brem ocurred
+   * @param[in] z atomic Z of element in which the dark brem ocurred
    */
   void setDarkBremMaterialZ(double z) { db_material_z_ = z; }
 
+  /**
+   * Get the Z of the element in which the dark brem ocurred
+   *
+   * @note This will return -1 if no dark brem ocurred within
+   * this event.
+   *
+   * @param[in] z atomic Z of element in which the dark brem ocurred
+   */
   double getDarkBremMaterialZ() const { return db_material_z_; }
 
   /**
@@ -151,7 +159,10 @@ class UserEventInformation : public G4VUserEventInformation {
   bool last_step_en_{false};
 
   /**
-   * elemental z in which dark brem occurred (-1 if didn't happen)
+   * atomic Z of the element in which dark brem occurred (-1 if didn't happen)
+   *
+   * The default is -1. and so will provide unphysical results if the
+   * dark brem did not occur within the event in question.
    */
   double db_material_z_{-1.};
 };

--- a/include/SimCore/UserEventInformation.h
+++ b/include/SimCore/UserEventInformation.h
@@ -29,13 +29,9 @@ class UserEventInformation : public G4VUserEventInformation {
    *
    * @param[in] z elemental z in which the dark brem ocurred
    */
-  void setDarkBremMaterialZ(double z) {
-    db_material_z_ = z;
-  }
+  void setDarkBremMaterialZ(double z) { db_material_z_ = z; }
 
-  double getDarkBremMaterialZ() const {
-    return db_material_z_;
-  }
+  double getDarkBremMaterialZ() const { return db_material_z_; }
 
   /**
    * Set the event weight.

--- a/src/SimCore/APrimePhysics.cxx
+++ b/src/SimCore/APrimePhysics.cxx
@@ -6,10 +6,10 @@
  */
 
 #include "SimCore/APrimePhysics.h"
-#include "SimCore/UserEventInformation.h"
 
 #include "G4DarkBreM/G4APrime.h"
 #include "G4DarkBreM/G4DarkBreMModel.h"
+#include "SimCore/UserEventInformation.h"
 
 // Geant4
 #include "G4Electron.hh"
@@ -32,11 +32,11 @@ const std::string APrimePhysics::NAME = "APrime";
  */
 static void store_element_z(const G4Element& element) {
   static_cast<UserEventInformation*>(
-      G4EventManager::GetEventManager()->GetUserInformation()
-      )->setDarkBremMaterialZ(element.GetZ());
+      G4EventManager::GetEventManager()->GetUserInformation())
+      ->setDarkBremMaterialZ(element.GetZ());
 }
 
-APrimePhysics::APrimePhysics(const framework::config::Parameters &params)
+APrimePhysics::APrimePhysics(const framework::config::Parameters& params)
     : G4VPhysicsConstructor(APrimePhysics::NAME),
       parameters_{params},
       process_{nullptr} {

--- a/src/SimCore/APrimePhysics.cxx
+++ b/src/SimCore/APrimePhysics.cxx
@@ -92,7 +92,7 @@ void APrimePhysics::ConstructProcess() {
           parameters_.getParameter<bool>("only_one_per_event"),
           1., /* global bias - should use bias operator instead */
           parameters_.getParameter<bool>("cache_xsec"));
-      proc->RegisterStorageMechanism(store_element_z);
+      process_->RegisterStorageMechanism(store_element_z);
     } else {
       EXCEPTION_RAISE("BadConf",
                       "Unrecognized model name '" + model_name + "'.");

--- a/src/SimCore/DetectorConstruction.cxx
+++ b/src/SimCore/DetectorConstruction.cxx
@@ -26,7 +26,8 @@ static bool isInEcal(G4LogicalVolume* vol, const std::string& vol_to_bias) {
            volumeName.contains("PCB") || volumeName.contains("strongback") ||
            volumeName.contains("Glue") || volumeName.contains("CFMix") ||
            volumeName.contains("Al") || volumeName.contains("C")) &&
-          volumeName.contains("volume"));
+          volumeName.contains("volume")) ||
+         (volumeName.contains("nohole_motherboard"));
 }
 
 /**

--- a/src/SimCore/SimulatorBase.cxx
+++ b/src/SimCore/SimulatorBase.cxx
@@ -24,6 +24,8 @@ void SimulatorBase::updateEventHeader(ldmx::EventHeader& eventHeader) const {
                                 event_info->getPNEnergy());
   eventHeader.setFloatParameter("total_electronuclear_energy",
                                 event_info->getENEnergy());
+  event_header.setFloatParameter("db_material_z",
+                                event_info->getDarkBremMaterialZ());
 }
 void SimulatorBase::onProcessEnd() {
   runManager_->TerminateEventLoop();

--- a/src/SimCore/SimulatorBase.cxx
+++ b/src/SimCore/SimulatorBase.cxx
@@ -24,7 +24,7 @@ void SimulatorBase::updateEventHeader(ldmx::EventHeader& eventHeader) const {
                                 event_info->getPNEnergy());
   eventHeader.setFloatParameter("total_electronuclear_energy",
                                 event_info->getENEnergy());
-  event_header.setFloatParameter("db_material_z",
+  eventHeader.setFloatParameter("db_material_z",
                                 event_info->getDarkBremMaterialZ());
 }
 void SimulatorBase::onProcessEnd() {


### PR DESCRIPTION
This PR is a few disparate patches related to my work studying the signal in the Ecal-as-Target analysis. They are relatively small changes that I have been using for several months and so I think it is fair to merge them in.

1. Put another entry in the event header parameters corresponding to the elemental-Z of the dark brem interaction. It will be `-1` if the dark brem did not occur. This is very helpful for analysis of a signal sample to make sure the distribution of elements on-which the dark brem occurred makes sense.
2. Update [G4DarkBreM to v2.0.0](https://github.com/tomeichlersmith/G4DarkBreM/releases/tag/v2.0.0). This major release of G4DarkBreM was made to support multiple-Z dark brem reference libraries which is helpful for making the EaT signal more realistic as it is distributed across many materials with widely varying Z in elements.
3. For the v14 detector, the ecal motherboards were not named in a way that was matched by the biasing operator attachment function so I patched that function to be able to pick up these volumes. They are thin PCB so including them does not affect the distributional shapes of any of the physics variables I was looking at, it just smoothed out the weight distribution a bit.