### PR TITLE
get process manager from particle singleton

### DIFF
--- a/include/SimCore/GammaPhysics.h
+++ b/include/SimCore/GammaPhysics.h
@@ -54,7 +54,7 @@ class GammaPhysics : public G4VPhysicsConstructor {
    * We don't do anything here since we are just attaching/updating
    * the photon physics.
    */
-  void ConstructParticle() final override;
+  void ConstructParticle() final;
 
   /**
    * We do two things for this call back during initialization.
@@ -66,13 +66,14 @@ class GammaPhysics : public G4VPhysicsConstructor {
    *    to lower its cross-section before any EM process is called
    *    (if need be).
    */
-  void ConstructProcess() final override;
+  void ConstructProcess() final;
 
  private:
   /**
    * The gamma to muons process.
    */
   G4GammaConversionToMuons gammaConvProcess;
+
   /**
    * Parameters from the configuration to pass along to the photonuclear model.
    */

--- a/src/SimCore/GammaPhysics.cxx
+++ b/src/SimCore/GammaPhysics.cxx
@@ -9,37 +9,37 @@
 
 namespace simcore {
 
-G4ProcessManager* GammaPhysics::GetGammaProcessManager() const {
-  if (G4Gamma::Gamma()->GetProcessManager()) return G4Gamma::Gamma()->GetProcessManager();
-  EXCEPTION_RAISE("GammaPhysics",
-                  "Was unable to access the process manager for photons, "
-                  "something is very wrong!");
-}
+GammaPhysics::GammaPhysics(const G4String& name,
+                           const framework::config::Parameters& parameters)
+    : G4VPhysicsConstructor(name),
+      modelParameters{parameters.getParameter<framework::config::Parameters>(
+          "photonuclear_model")} {}
 
-void GammaPhysics::SetPhotonNuclearAsFirstProcess() const {
-  auto processManager{GetGammaProcessManager()};
-  // Get the process list associated with the gamma.
-  const auto processes{processManager->GetProcessList()};
+void GammaPhysics::ConstructParticle() {}
 
-  for (int i{0}; i < processes->size(); ++i) {
-    const auto process{(*processes)[i]};
-    const auto processName{process->GetProcessName()};
-    if (processName == "photonNuclear") {
-      processManager->SetProcessOrderingToFirst(
-          process, G4ProcessVectorDoItIndex::idxAll);
-    }
-  }
-}
 void GammaPhysics::ConstructProcess() {
-  G4ProcessManager* processManager = GetGammaProcessManager();
-
+  G4ProcessManager* processManager = G4Gamma::Gamma()->GetProcessManager();
+  if (processManager == nullptr) {
+    EXCEPTION_RAISE("GammaPhysics",
+                    "Was unable to access the process manager for photons, "
+                    "something is very wrong!");
+  }
+  // configure our PN model based on runtime parameters
   auto pn = PhotoNuclearModel::Factory::get().make(
       modelParameters.getParameter<std::string>("class_name"),
       modelParameters.getParameter<std::string>("instance_name"),
       modelParameters);
   pn->removeExistingModel(processManager);
   pn->ConstructGammaProcess(processManager);
-  SetPhotonNuclearAsFirstProcess();
+  // put the PN process first in the ordering in case PN biasing is happening
+  const auto processes{processManager->GetProcessList()};
+  for (int i{0}; i < processes->size(); i++) {
+    const auto process{(*processes)[i]};
+    if (process->GetProcessName() == "photonNuclear") {
+      processManager->SetProcessOrderingToFirst(
+          process, G4ProcessVectorDoItIndex::idxAll);
+    }
+  }
   // Add the gamma -> mumu to the physics list.
   processManager->AddDiscreteProcess(&gammaConvProcess);
 }

--- a/src/SimCore/GammaPhysics.cxx
+++ b/src/SimCore/GammaPhysics.cxx
@@ -9,31 +9,8 @@
 
 namespace simcore {
 
-// needed for GEANT4 10.3.0 and later
-//
-// TODO: I (Einar) don't think this really is necessary if we change
-// GetGammaProcessManager below
-#ifndef aParticleIterator
-#define aParticleIterator \
-  ((subInstanceManager.offset[g4vpcInstanceID])._aParticleIterator)
-#endif
-
 G4ProcessManager* GammaPhysics::GetGammaProcessManager() const {
-  /**
-   * Not entirely clear that there isn't a simpler way to do this, but to keep
-   * this function extraction to a pure refactoring, I'm leaving it here for
-   * now. /Einar
-   */
-  aParticleIterator->reset();
-
-  // Loop through all of the particles and find the "gamma".
-  while ((*aParticleIterator)()) {
-    auto particle{aParticleIterator->value()};
-    auto particleName{particle->GetParticleName()};
-    if (particleName == "gamma") {
-      return particle->GetProcessManager();
-    }
-  }
+  if (G4Gamma::Gamma()->GetProcessManager()) return G4Gamma::Gamma()->GetProcessManager();
   EXCEPTION_RAISE("GammaPhysics",
                   "Was unable to access the process manager for photons, "
                   "something is very wrong!");

--- a/src/SimCore/GammaPhysics.cxx
+++ b/src/SimCore/GammaPhysics.cxx
@@ -31,7 +31,24 @@ void GammaPhysics::ConstructProcess() {
       modelParameters);
   pn->removeExistingModel(processManager);
   pn->ConstructGammaProcess(processManager);
-  // put the PN process first in the ordering in case PN biasing is happening
+  /**
+   * Put the PN process first in the ordering in case PN biasing is happening.
+   *
+   * Process ordering is a complicated concept and unfortunately
+   * its affect on biasing is poorly documented. What has been said is
+   * that some processes _need_ to be called _last_[1]. In addition,
+   * the practical experience of working on defining a custom
+   * process for
+   * [G4DarkBreM](https://github.com/LDMX-Software/G4DarkBreM)
+   * showed that sometimes Geant4 does
+   * not get through the full list of processes but it always starts
+   * at the beginning. For these reasons, we put the PN process first
+   * in the ordering so that we can insure it is always check by Geant4
+   * before continuing.
+   *
+   * [1]
+   * https://indico.cern.ch/event/58317/contributions/2047449/attachments/992300/1411062/PartDef-ProcMan-AS.pdf
+   */
   const auto processes{processManager->GetProcessList()};
   for (int i{0}; i < processes->size(); i++) {
     const auto process{(*processes)[i]};


### PR DESCRIPTION
In my adventures with Geant4 developing the G4DarkBreM package, I found that recent versions (at least all since our tag of 10.2) have a method for accessing a particle's process manager from the particle itself. Since the particle is a singleton created when requested, we can always access it and ask for the process manager. If we call the function too early in processing (perhaps if we were to manually call `GammaPhysics::ConstructProcess` at the wrong time during initialization), then the manager would not be created and attached yet, but this will work if we allow G4 to call `ConstructProcess` at the right time.

### To Do
I just copied this in-browser so I haven't even tried compiling it yet.
- [x] get compiling and running
- [x] check tests in ldmx-sw specifically focused on gamma conversion ones