### PR TITLE
add option to filter by run number as well as event number

### DIFF
--- a/include/SimCore/ReSimulator.h
+++ b/include/SimCore/ReSimulator.h
@@ -27,6 +27,13 @@ class ReSimulator : public SimulatorBase {
 
  private:
   /**
+   * Check if an event should be skipped during resimulation
+   *
+   * @param[in] event handle to the current event being processed
+   */
+  bool skip(framework::Event& event) const;
+
+  /**
    * List of events in the input files that should be resimulated if
    * `resimulate_all_events` is false.
    *
@@ -35,7 +42,7 @@ class ReSimulator : public SimulatorBase {
    * @note: If an event in `events_to_resimulate_` is not part of the
    * input file, it will be ignored.
    */
-  std::vector<std::pair<int,int>> events_to_resimulate_;
+  std::vector<std::pair<int, int>> events_to_resimulate_;
 
   /**
    * Whether to resimulate all events in the input files

--- a/include/SimCore/ReSimulator.h
+++ b/include/SimCore/ReSimulator.h
@@ -10,14 +10,14 @@ class ReSimulator : public SimulatorBase {
  public:
   ReSimulator(const std::string& name, framework::Process& process)
       : SimulatorBase{name, process} {}
-  /*
+  /**
    * Callback for the processor to configure itself from the given set
    * of parameters.
    *
    * @param parameters ParameterSet for configuration.
    */
   void configure(framework::config::Parameters& parameters) final override;
-  /*
+  /**
    * Run resimulation if the event is part of the requested sets of events to
    * resimulate
    *
@@ -26,7 +26,7 @@ class ReSimulator : public SimulatorBase {
   void produce(framework::Event& event) override;
 
  private:
-  /*
+  /**
    * List of event numbers in the input files that should be resimulated if
    * `resimulate_all_events` is false.
    *
@@ -34,6 +34,24 @@ class ReSimulator : public SimulatorBase {
    * input file, it will be ignored.
    */
   std::vector<int> events_to_resimulate_;
+
+  /**
+   * List of run numbers in the input files that should be resimulated if
+   * `resimulate_all_events` is false.
+   *
+   * @note: If a run number in `runs_to_resimulate_` is not part of the
+   * input file, it will be ignored.
+   *
+   * The list of runs to resimulate comes in one of three forms:
+   * 1. Empty: If no runs are given, we only match based off the event number.
+   * 2. Single Entry: If only one run is given, then we require the run number
+   *    to be that entry for all events requested to resimulate.
+   * 3. More than one entry: In this case, we require the length of this list
+   *    to be the same as the length of the events to resimulate so that we 
+   *    only resimulate events where the event/run *pair* matches a corresponding
+   *    *pair* in the events and runs to resimulate lists.
+   */
+  std::vector<int> runs_to_resimulate_;
 
   /**
    * Whether to resimulate all events in the input files

--- a/include/SimCore/ReSimulator.h
+++ b/include/SimCore/ReSimulator.h
@@ -27,43 +27,33 @@ class ReSimulator : public SimulatorBase {
 
  private:
   /**
-   * List of event numbers in the input files that should be resimulated if
+   * List of events in the input files that should be resimulated if
    * `resimulate_all_events` is false.
    *
-   * @note: If an event number in `events_to_resimulate_` is not part of the
+   * Each event is identified uniquely by its run number and event number.
+   *
+   * @note: If an event in `events_to_resimulate_` is not part of the
    * input file, it will be ignored.
    */
-  std::vector<int> events_to_resimulate_;
-
-  /**
-   * List of run numbers in the input files that should be resimulated if
-   * `resimulate_all_events` is false.
-   *
-   * @note: If a run number in `runs_to_resimulate_` is not part of the
-   * input file, it will be ignored.
-   *
-   * The list of runs to resimulate comes in one of three forms:
-   * 1. Empty: If no runs are given, we only match based off the event number.
-   * 2. Single Entry: If only one run is given, then we require the run number
-   *    to be that entry for all events requested to resimulate.
-   * 3. More than one entry: In this case, we require the length of this list
-   *    to be the same as the length of the events to resimulate so that we 
-   *    only resimulate events where the event/run *pair* matches a corresponding
-   *    *pair* in the events and runs to resimulate lists.
-   */
-  std::vector<int> runs_to_resimulate_;
+  std::vector<std::pair<int,int>> events_to_resimulate_;
 
   /**
    * Whether to resimulate all events in the input files
    */
-  bool resimulate_all_events;
+  bool resimulate_all_events_;
+
+  /**
+   * Whether or not we should check the run number when seeing
+   * if a specific event should be resimulated
+   */
+  bool care_about_run_;
 
   /*
    * How many events have already been resimulated. This determines the event
    * number in the output file, since more than one input file can be used.
    *
    */
-  int events_resimulated = 0;
+  int events_resimulated_ = 0;
 };
 }  // namespace simcore
 

--- a/python/simulator.py.in
+++ b/python/simulator.py.in
@@ -135,7 +135,7 @@ class simulator(Producer):
                 sds.ScoringPlaneSD.magnet()
                 ])
 
-    def resimulate(self, which_events = None):
+    def resimulate(self, which_events = None, which_runs = None):
         """Create a resimulator based on the simulator configuration.
 
         This is intended to ensure that a resimulator has the same configuration
@@ -147,7 +147,7 @@ class simulator(Producer):
 
         Parameters
         ----------
-            which_events : list of event numbers, optional
+        which_events : list of event numbers, optional
             Which events from the input files to resimulate. If None,
             resimulate all events.
 
@@ -155,7 +155,19 @@ class simulator(Producer):
             ignored.
 
             For multiple input files, if an event number is present within more
-            than one input file all versions will be resimulated.
+            than one input file all versions will be resimulated unless the which_runs
+            parameters is used to distinguish them.
+
+        which_runs : list of run numbers, optional
+            Which runs from the input files to resimulate, ignored if no
+            events are listed. Runs not present in the input files will be
+            ignored.
+
+            If not provided, all runs will be resimulated (i.e. the run number
+            check is ignored). If only one value is provided, all events requested
+            are also required to have that value for their run number to be resimulated.
+            If more than one value is provided, it must be the same length as the
+            number of events requested so that the event/run number pair can be required.
 
         """
         resimulator = self
@@ -163,11 +175,24 @@ class simulator(Producer):
         if which_events is None:
             resimulator.resimulate_all_events = True
             resimulator.events_to_resimulate = [ ]
+            resimulator.runs_to_resimulate = [ ]
         elif isinstance(which_events, list):
             resimulator.resimulate_all_events = False
             resimulator.events_to_resimulate = which_events
             if len(which_events) == 0:
                 raise ValueError('which_events must contain at least one element if provided')
+            if which_runs is None:
+                resimulator.runs_to_resimulate = [ ]
+            elif isinstance(which_runs, int):
+                resimulator.runs_to_resimulate = [ which_runs ]
+            elif isinstance(which_runs, list):
+                if len(which_runs) == 0:
+                    raise ValueError('which_runs must have at least one value if provided as a list')
+                if len(which_runs) != len(which_events):
+                    raise ValueError('which_runs must have the same number of entries as which_events if more than one run is provided')
+                resimulator.runs_to_resimulate = which_runs
+            else:
+                raise ValueError('which_runs must be an int or a list of ints if provided')
         else:
             raise ValueError('which_events must be a list if provided')
         return resimulator

--- a/python/simulator.py.in
+++ b/python/simulator.py.in
@@ -6,6 +6,25 @@ with several helpful member functions.
 
 from @PYTHON_PACKAGE_NAME@.Framework.ldmxcfg import Producer
 
+class _EventToReSim:
+    """A class to hold the information identifying a specific event we wish to re-simulate
+
+    This is an internal class used by simulator.resimulate in order to pass the event
+    identification to the ReSimulator class
+
+    Attributes
+    ----------
+    run: int
+        run number of the event to re-sim, -1 if we don't care about the run
+    event: int
+        event number to re-sim, required
+    """
+
+    def __init__(self, event, run = -1):
+        self.event = event
+        self.run = run
+
+
 class simulator(Producer):
     """A instance of the simulation configuration
 
@@ -174,23 +193,25 @@ class simulator(Producer):
         resimulator.className = 'simcore::ReSimulator'
         if which_events is None:
             resimulator.resimulate_all_events = True
+            resimulator.care_about_run = False
             resimulator.events_to_resimulate = [ ]
-            resimulator.runs_to_resimulate = [ ]
         elif isinstance(which_events, list):
             resimulator.resimulate_all_events = False
-            resimulator.events_to_resimulate = which_events
             if len(which_events) == 0:
                 raise ValueError('which_events must contain at least one element if provided')
             if which_runs is None:
-                resimulator.runs_to_resimulate = [ ]
+                resimulator.care_about_run = False
+                resimulator.events_to_resimulate = [ _EventToReSim(event) for event in which_events ]
             elif isinstance(which_runs, int):
-                resimulator.runs_to_resimulate = [ which_runs ]
+                resimulator.care_about_run = True
+                resimulator.events_to_resimulate = [ _EventToReSim(event, which_runs) for event in which_events ]
             elif isinstance(which_runs, list):
                 if len(which_runs) == 0:
                     raise ValueError('which_runs must have at least one value if provided as a list')
                 if len(which_runs) != len(which_events):
                     raise ValueError('which_runs must have the same number of entries as which_events if more than one run is provided')
-                resimulator.runs_to_resimulate = which_runs
+                resimulator.care_about_run = True
+                resimulator.runs_to_resimulate = [ _EventToReSim(event, run) for event, run in zip(which_events, which_runs) ]
             else:
                 raise ValueError('which_runs must be an int or a list of ints if provided')
         else:


### PR DESCRIPTION
This is helpful for people like me who have massive samples of heavily-filtered simulations. The best way to generate these samples is across many runs but then merge the resulting files. This results in several runs per file and often an event from one run is aborted by the simulation while the same event number from a different run is the event I wish to resimulate.