### PR TITLE
Allow kaon physics to be configurable at runtime by the user

### DIFF
--- a/include/SimCore/Event/SimParticle.h
+++ b/include/SimCore/Event/SimParticle.h
@@ -38,6 +38,7 @@ class SimParticle {
     photonNuclear,
     GammaToMuPair,
     eDarkBrem,
+    Decay,
     // Only add additional processes to the end of this list!
   };
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -4,6 +4,8 @@
 #include <G4DecayTable.hh>
 #include <G4KaonMinus.hh>
 #include <G4KaonPlus.hh>
+#include <G4KaonZeroLong.hh>
+#include <G4KaonZeroShort.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4VDecayChannel.hh>
 #include <G4VPhysicsConstructor.hh>
@@ -39,7 +41,7 @@ class KaonPhysics : public G4VPhysicsConstructor {
    * K^+ -> \pi^+ + \pi^0
    * K^+ -> \pi^+ + \pi^- + \pi^+
    * K^+ -> \pi^+ + \pi^0 + \pi^0
-   * K^+ -> \pi^0 + e^+ + \nu_\mu
+   * K^+ -> \pi^0 + e^+ + \nu_e
    * K^+ -> \pi^0 + \mu^+ + \nu_\mu
    *
    * And vice versa for K^-.
@@ -47,7 +49,7 @@ class KaonPhysics : public G4VPhysicsConstructor {
    * that process in the corresponding parameter as well as the position in
    * the decay table.
    */
-  enum KaonDecayChannel {
+  enum ChargedKaonDecayChannel {
     mu_nu = 0,
     pi_pi0 = 1,
     pi_pi_pi = 2,
@@ -55,15 +57,52 @@ class KaonPhysics : public G4VPhysicsConstructor {
     pi0_e_nu = 4,
     pi0_mu_nu = 5
   };
-  // Factor to scale the K^+/K^- lifetimes by. To reduce the lifetime of all
-  // charged kaons by a factor 50, set these to 1/50.
+  /*
+   *
+   * Corresponding entries for the K^0_L. Note that K^0_L and K^0_S decays are
+   * not symmetric like the charged ones so they need to be handled manually.
+   *
+   * The processes are
+   *
+   * K^0_L -> \pi^0 + \pi^0 + \pi^0
+   * K^0_L -> \pi^0 + \pi^+ + \pi^-
+   * K^0_L -> \pi^- + e^+ + \nu_e
+   * K^0_L -> \pi^+ + e^- + \nu_e
+   * K^0_L -> \pi^- + \mu^+ + \nu_\mu
+   * K^0_L -> \pi^+ + \mu^- + \nu_\mu
+   *
+   * and
+   *
+   * K^0_S -> \pi^+ + \pi^-
+   * K^0_S -> \pi^0 + \pi^0
+   *
+   **/
+  enum KaonZeroLongDecayChannel {
+    pi0_pi0_pi0 = 0,
+    pi0_pip_pim = 1,
+    pip_e_nu = 2,
+    pim_e_nu = 3,
+    pim_mu_nu = 4,
+    pip_mu_nu = 5,
+  };
+  enum KaonZeroShortDecayChannel {
+    pip_pim = 0,
+    pi0_pi0 = 1,
+  };
+
+  // Factor to scale the K^+/K^-/K^0_L/K^0_S lifetimes by. To reduce the
+  // lifetime of all charged kaons by a factor 50, set these to 1/50.
   double kplus_lifetime_factor{1};
   double kminus_lifetime_factor{1};
+  double k0l_lifetime_factor{1};
+  double k0s_lifetime_factor{1};
 
   // Branching ratios for each of the decay processes listed in the
-  // KaonDecayChannel enumerator
+  // KaonDecayChannel enumerators
   std::vector<double> kplus_branching_ratios;
   std::vector<double> kminus_branching_ratios;
+  std::vector<double> k0l_branching_ratios;
+  std::vector<double> k0s_branching_ratios;
 
  public:
   KaonPhysics(const G4String& name,
@@ -71,8 +110,7 @@ class KaonPhysics : public G4VPhysicsConstructor {
   virtual ~KaonPhysics() = default;
 
   /**
-   *  Set the lifetime and branching ratios for one of the charged kaon
-   *  species.
+   *  Set the lifetime and branching ratios for one of the kaon species.
    */
   void setDecayProperties(G4ParticleDefinition* kaon,
                           const std::vector<double>& branching_ratios,

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -24,8 +24,6 @@ namespace simcore {
  * produced in the simulation, in particular setting their lifetime and
  * branching ratios
  *
- * @note Only affects charged kaons, but similar changes could be added for the
- * neutral ones in a rather straight-forward manner.
  */
 
 class KaonPhysics : public G4VPhysicsConstructor {

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -69,6 +69,14 @@ class KaonPhysics : public G4VPhysicsConstructor {
   KaonPhysics(const G4String& name,
               const framework::config::Parameters& parameters);
   virtual ~KaonPhysics() = default;
+
+  /**
+   *  Set the lifetime and branching ratios for one of the charged kaon
+   *  species.
+   */
+  void setDecayProperties(G4ParticleDefinition* kaon,
+                          const std::vector<double>& branching_ratios,
+                          double lifetime_factor) const;
 };
 }  // namespace simcore
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -77,6 +77,27 @@ class KaonPhysics : public G4VPhysicsConstructor {
   void setDecayProperties(G4ParticleDefinition* kaon,
                           const std::vector<double>& branching_ratios,
                           double lifetime_factor) const;
+
+  /**
+   * Construct/Update particles
+   *
+   * Update the particle definitions for charged kaons
+   *
+   * 1. Scale their lifetime by the corresponding lifetime factor
+   *
+   * 2. Set their branching ratios to those in the corresponding branching
+   * raito parameter
+   */
+
+  void ConstructParticle() override;
+
+  /**
+   * Construct processes
+   *
+   * We don't do anything here since we are just attaching/updating
+   * the kaon particle definitions.
+   */
+  void ConstructProcess() override{};
 };
 }  // namespace simcore
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -64,6 +64,11 @@ class KaonPhysics : public G4VPhysicsConstructor {
   // KaonDecayChannel enumerator
   std::vector<double> kplus_branching_ratios;
   std::vector<double> kminus_branching_ratios;
+
+ public:
+  KaonPhysics(const G4String& name,
+              const framework::config::Parameters& parameters);
+  virtual ~KaonPhysics() = default;
 };
 }  // namespace simcore
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -55,6 +55,15 @@ class KaonPhysics : public G4VPhysicsConstructor {
     pi0_e_nu = 4,
     pi0_mu_nu = 5
   };
+  // Factor to scale the K^+/K^- lifetimes by. To reduce the lifetime of all
+  // charged kaons by a factor 50, set these to 1/50.
+  double kplus_lifetime_factor{1};
+  double kminus_lifetime_factor{1};
+
+  // Branching ratios for each of the decay processes listed in the
+  // KaonDecayChannel enumerator
+  std::vector<double> kplus_branching_ratios;
+  std::vector<double> kminus_branching_ratios;
 };
 }  // namespace simcore
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -27,6 +27,34 @@ namespace simcore {
  */
 
 class KaonPhysics : public G4VPhysicsConstructor {
+ private:
+  /**
+   *
+   * Represents the 6 possible decay channels for charged kaons in Geant4 (See
+   * G4KaonMinus.cc and G4KaonPlus.cc in the Geant4 sources) in the order they
+   * appear in the decay table.
+   *
+   * The processes are
+   * K^+ -> \mu^+ + \nu_\mu
+   * K^+ -> \pi^+ + \pi^0
+   * K^+ -> \pi^+ + \pi^- + \pi^+
+   * K^+ -> \pi^+ + \pi^0 + \pi^0
+   * K^+ -> \pi^0 + e^+ + \nu_\mu
+   * K^+ -> \pi^0 + \mu^+ + \nu_\mu
+   *
+   * And vice versa for K^-.
+   * The indices here correspond to the position of the branching ratio for
+   * that process in the corresponding parameter as well as the position in
+   * the decay table.
+   */
+  enum KaonDecayChannel {
+    mu_nu = 0,
+    pi_pi0 = 1,
+    pi_pi_pi = 2,
+    pi_pi0_pi0 = 3,
+    pi0_e_nu = 4,
+    pi0_mu_nu = 5
+  };
 };
 }  // namespace simcore
 

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -55,7 +55,7 @@ class KaonPhysics : public G4VPhysicsConstructor {
     pi0_e_nu = 4,
     pi0_mu_nu = 5
   };
-  /*
+  /**
    *
    * Corresponding entries for the K^0_L. Note that K^0_L and K^0_S decays are
    * not symmetric like the charged ones so they need to be handled manually.

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -1,0 +1,33 @@
+#ifndef SIMCORE_KAON_PHYSICS_H
+#define SIMCORE_KAON_PHYSICS_H
+
+#include <G4DecayTable.hh>
+#include <G4KaonMinus.hh>
+#include <G4KaonPlus.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4VDecayChannel.hh>
+#include <G4VPhysicsConstructor.hh>
+#include <numeric>
+#include <vector>
+
+#include "Framework/Configure/Parameters.h"
+#include "Framework/Exception/Exception.h"
+
+namespace simcore {
+
+/**
+ * @class KaonPhysics
+ *
+ * @brief Allows the configuration of properties of kaons
+ * produced in the simulation, in particular setting their lifetime and
+ * branching ratios
+ *
+ * @note Only affects charged kaons, but similar changes could be added for the
+ * neutral ones in a rather straight-forward manner.
+ */
+
+class KaonPhysics : public G4VPhysicsConstructor {
+};
+}  // namespace simcore
+
+#endif /* SIMCORE_KAON_PHYSICS_H */

--- a/include/SimCore/RunManager.h
+++ b/include/SimCore/RunManager.h
@@ -109,9 +109,6 @@ class RunManager : public G4RunManager {
    */
   bool useRootSeed_{false};
 
-  /** ConditionsInterface
-   */
-  [[maybe_unused]] ConditionsInterface& conditionsIntf_;
 
 };  // RunManager
 }  // namespace simcore

--- a/include/SimCore/RunManager.h
+++ b/include/SimCore/RunManager.h
@@ -43,8 +43,7 @@ class RunManager : public G4RunManager {
   /**
    * Class constructor.
    */
-  RunManager(framework::config::Parameters& parameters,
-             ConditionsInterface&);
+  RunManager(framework::config::Parameters& parameters, ConditionsInterface&);
 
   /**
    * Class destructor.
@@ -108,7 +107,6 @@ class RunManager : public G4RunManager {
    * Should we use random seed from root file?
    */
   bool useRootSeed_{false};
-
 
 };  // RunManager
 }  // namespace simcore

--- a/include/SimCore/RunManager.h
+++ b/include/SimCore/RunManager.h
@@ -44,7 +44,7 @@ class RunManager : public G4RunManager {
    * Class constructor.
    */
   RunManager(framework::config::Parameters& parameters,
-             ConditionsInterface& ci);
+             ConditionsInterface&);
 
   /**
    * Class destructor.

--- a/include/SimCore/RunManager.h
+++ b/include/SimCore/RunManager.h
@@ -24,6 +24,7 @@
 /*   Framework   */
 /*~~~~~~~~~~~~~~~*/
 #include "Framework/Configure/Parameters.h"
+#include "SimCore/KaonPhysics.h"
 
 namespace simcore {
 

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -46,7 +46,15 @@ class KaonPhysics():
         self.kplus_lifetime_factor = 1.
         self.kminus_lifetime_factor = 1.
 
+
     def upKaons():
+        """Returns a configuration of the kaon physics corresponding
+        to the changes that were made in
+        https://github.com/ldmx-software/geant4/tree/LDMX.upKaons_mod
+
+        Reduces the charged kaon lifetimes by a factor 1/50 and forces
+        decays to be into one of the leptonic decay modes.
+        """
         kaon_physics = KaonPhysics()
         kaon_physics.kplus_branching_ratios = [
             0.8831,  # K^+ -> mu^+ + nu_mu

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -86,6 +86,9 @@ class KaonPhysics():
 
         Reduces the charged kaon lifetimes by a factor 1/50 and forces
         decays to be into one of the leptonic decay modes.
+
+        See
+        https://github.com/LDMX-Software/geant4/commit/25228b8b1fbad913b4933b7c0d3951ebe36d404c
         """
         kaon_physics = KaonPhysics()
         kaon_physics.kplus_branching_ratios = [
@@ -107,3 +110,27 @@ class KaonPhysics():
         kaon_physics.kplus_lifetime_factor = 1/50.
         kaon_physics.kminus_lifetime_factor = 1/50.
         return kaon_physics
+
+    def __setattr__(self, key, value):
+        """Ensure that attempts to set the branching ratios give a total of
+        something close to 1 and that the lifetime factors are positive.
+
+        Note that Geant4's defaults are not exactly equal to one, but something
+        significantly different from one is likely to be a mistake.
+
+        """
+        if 'branching_ratios' in key:
+            # super().__setattr__(key, value)
+            if not isinstance(value, list):
+                raise TypeError(f'Values of branching ratios ({key}) need to be lists')
+            if abs(sum(value) - 1) > 0.95:
+                raise ValueError(f'Total of branching ratios in {key} significantly different from one, was {value}.')
+            super().__setattr__(key, value)
+        elif 'lifetime' in key:
+            if not isinstance(value, float):
+                raise TypeError(f'Lifetime parameter ({key}) needs to be floating-point')
+            if value < 0:
+                raise ValueError(f'Lifetime parameter ({key}) needs to be positive')
+            pass
+        else:
+            super().__setattr__(key, value)

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -1,0 +1,23 @@
+
+class KaonPhysics():
+
+    def __init__(self):
+        self.kplus_branching_ratios = [
+            0.6355,  # K^+ -> mu^+ + nu_mu
+            0.2066,  # K^+ -> pi^+ + pi^0
+            0.0559,  # K^+ -> pi^+ + pi^- + pi^+
+            0.01761, # K^+ -> pi^+ + pi^0 + pi^0
+            0.0507,  # K^+ -> pi^0 + e^+ + nu_e
+            0.0335,  # K^+ -> pi^0 + mu^+ + nu_mu
+        ]
+        self.kminus_branching_ratios = [
+            0.6355,  # K^- -> mu^- + anti_nu_mu
+            0.2066,  # K^- -> pi^- + pi^0
+            0.0559,  # K^- -> pi^- + pi^+ + pi^-
+            0.01761, # K-+ -> pi^- + pi^0 + pi^0
+            0.0507,  # K-+ -> pi^0 + e^- + anti_nu_e
+            0.0335,  # K-+ -> pi^0 + mu^- + anti_nu_mu
+        ]
+        self.kplus_lifetime_factor = 1.
+        self.kminus_lifetime_factor = 1.
+

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -21,3 +21,24 @@ class KaonPhysics():
         self.kplus_lifetime_factor = 1.
         self.kminus_lifetime_factor = 1.
 
+    def upKaons():
+        kaon_physics = KaonPhysics()
+        kaon_physics.kplus_branching_ratios = [
+            0.8831,  # K^+ -> mu^+ + nu_mu
+            0.,  # K^+ -> pi^+ + pi^0
+            0.,  # K^+ -> pi^+ + pi^- + pi^+
+            0., # K^+ -> pi^+ + pi^0 + pi^0
+            0.0704,  # K^+ -> pi^0 + e^+ + nu_e
+            0.0465,  # K^+ -> pi^0 + mu^+ + nu_mu
+        ]
+        kaon_physics.kminus_branching_ratios = [
+            0.8831,  # K^- -> mu^- + anti_nu_mu
+            0.,  # K^- -> pi^- + pi^0
+            0.,  # K^- -> pi^- + pi^+ + pi^-
+            0., # K-+ -> pi^- + pi^0 + pi^0
+            0.0704,  # K-+ -> pi^0 + e^- + anti_nu_e
+            0.0464,  # K-+ -> pi^0 + mu^- + anti_nu_mu
+        ]
+        kaon_physics.kplus_lifetime_factor = 1/50.
+        kaon_physics.kminus_lifetime_factor = 1/50.
+        return kaon_physics

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -123,8 +123,9 @@ class KaonPhysics():
             # super().__setattr__(key, value)
             if not isinstance(value, list):
                 raise TypeError(f'Values of branching ratios ({key}) need to be lists')
-            if abs(sum(value) - 1) > 0.95:
-                raise ValueError(f'Total of branching ratios in {key} significantly different from one, was {value}.')
+            total_branching_ratio = sum(value)
+            if abs(total_branching_ratio- 1) > 0.05:
+                raise ValueError(f'Total of branching ratios in {key} significantly different from one, was {total_branching_ratio}: {value}.')
             super().__setattr__(key, value)
         elif 'lifetime' in key:
             if not isinstance(value, float):

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -120,21 +120,19 @@ class KaonPhysics():
 
         """
         if 'branching_ratios' in key:
-            # super().__setattr__(key, value)
             if not isinstance(value, list):
                 raise TypeError(f'Values of branching ratios ({key}) need to be lists')
             total_branching_ratio = sum(value)
             if abs(total_branching_ratio- 1) > 0.05:
                 raise ValueError(f'Total of branching ratios in {key} significantly different from one, was {total_branching_ratio}: {value}.')
-            super().__setattr__(key, value)
         elif 'lifetime' in key:
             if not isinstance(value, float):
                 raise TypeError(f'Lifetime parameter ({key}) needs to be floating-point')
             if value < 0:
                 raise ValueError(f'Lifetime parameter ({key}) needs to be positive')
-            pass
-        else:
-            super().__setattr__(key, value)
+
+        # Everything ok!
+        super().__setattr__(key, value)
 
     def __repr__(self):
         return (

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -6,9 +6,12 @@ class KaonPhysics():
     ----------
     kplus_branching_ratios : list[float]
     kminus_branching_ratios : list[float]
-        List of the desired branching ratios for charged kaons. The entries
+    k0l_branching_ratios : list[float]
+    k0s_branching_ratios : list[float]
+        List of the desired branching ratios for kaons. The entries
         correspond go the following processes
 
+        For charged kaons
         - 0: K -> mu + v
         - 1: K -> pi + pi0
         - 2: K -> 3 pi
@@ -16,15 +19,30 @@ class KaonPhysics():
         - 4: K -> pi0 + e + v
         - 5: K -> pi0 + mu + v
 
+        For Klong
+        - 0: K -> 3 pi0
+        - 1: K -> pi0 + pi+ + pi-
+        - 2: K -> pi- + e+ + v
+        - 3: K -> pi+ + e- + v
+        - 4: K -> pi- + mu+ + v
+        - 5: K -> pi+ + mu- + v
+
+        For Kshort:
+        - 0: K -> pi+ + pi-
+        - 1: K -> 2 pi0
+
         See the sources for Geant4's definitions and branching ratios
-        (G4KaonMinus.cc, G4KaonPlus.cc). The default branching ratios
-        correspond to the Geant4 defaults.
+        (G4KaonMinus.cc, G4KaonPlus.cc, KaonZeroLong.cc, KaonZeroShort.cc). The
+        default branching ratios correspond to the Geant4 defaults.
 
     kplus_lifetime_factor : float
     kminus_lifetime_factor : float
+    k0l_lifetime_factor : float
+    k0s_lifetime_factor : float
 
-        Multiplicative factor to scale the lifetime of charged kaons by.
-        Default is to scale by 1 (no scaling)
+        Multiplicative factor to scale the lifetime of kaons by. Default is to
+        scale by 1 (no scaling)
+
     """
     def __init__(self):
         self.kplus_branching_ratios = [
@@ -43,8 +61,22 @@ class KaonPhysics():
             0.0507,  # K-+ -> pi^0 + e^- + anti_nu_e
             0.0335,  # K-+ -> pi^0 + mu^- + anti_nu_mu
         ]
+        self.k0l_branching_ratios = [
+            0.1952, # K^0_L -> pi^0 + pi^0 + pi^0
+            0.1254, # K^0_L -> pi^0 + pi^+ + pi^-
+            0.2027, # K^0_L -> pi^- + e^+ + nu_e
+            0.2027, # K^0_L -> pi^+ + e^- + anti_nu_e
+            0.1352, # K^0_L -> pi^- + mu^+ + nu_mu
+            0.1352, # K^0_L -> pi^+ + mu^- + anti_nu_mu
+        ]
+        self.k0s_branching_ratios = [
+            0.6920, # K^0_S -> pi^+ + pi^-
+            0.3069, # K^0_S -> pi^0 + pi^0
+        ]
         self.kplus_lifetime_factor = 1.
         self.kminus_lifetime_factor = 1.
+        self.k0l_lifetime_factor = 1.
+        self.k0s_lifetime_factor = 1.
 
 
     def upKaons():

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -1,6 +1,31 @@
 
 class KaonPhysics():
+    """Parameters that determine the physics of kaons in the simulation
 
+    Parameters
+    ----------
+    kplus_branching_ratios : list[float]
+    kminus_branching_ratios : list[float]
+        List of the desired branching ratios for charged kaons. The entries
+        correspond go the following processes
+
+        - 0: K -> mu + v
+        - 1: K -> pi + pi0
+        - 2: K -> 3 pi
+        - 3: K -> pi + 2 pi0
+        - 4: K -> pi0 + e + v
+        - 5: K -> pi0 + mu + v
+
+        See the sources for Geant4's definitions and branching ratios
+        (G4KaonMinus.cc, G4KaonPlus.cc). The default branching ratios
+        correspond to the Geant4 defaults.
+
+    kplus_lifetime_factor : float
+    kminus_lifetime_factor : float
+
+        Multiplicative factor to scale the lifetime of charged kaons by.
+        Default is to scale by 1 (no scaling)
+    """
     def __init__(self):
         self.kplus_branching_ratios = [
             0.6355,  # K^+ -> mu^+ + nu_mu

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -135,3 +135,17 @@ class KaonPhysics():
             pass
         else:
             super().__setattr__(key, value)
+
+    def __repr__(self):
+        return (
+            f"KaonPhysics(\n"
+            f"  kplus_branching_ratios={self.kplus_branching_ratios},\n"
+            f"  kminus_branching_ratios={self.kminus_branching_ratios},\n"
+            f"  k0l_branching_ratios={self.k0l_branching_ratios},\n"
+            f"  k0s_branching_ratios={self.k0s_branching_ratios},\n"
+            f"  kplus_lifetime_factor={self.kplus_lifetime_factor},\n"
+            f"  kminus_lifetime_factor={self.kminus_lifetime_factor},\n"
+            f"  k0l_lifetime_factor={self.k0l_lifetime_factor},\n"
+            f"  k0s_lifetime_factor={self.k0s_lifetime_factor}\n"
+            f")"
+        )

--- a/python/simulator.py.in
+++ b/python/simulator.py.in
@@ -92,6 +92,9 @@ class simulator(Producer):
         from LDMX.SimCore import photonuclear_models
         self.photonuclear_model = photonuclear_models.BertiniModel()
 
+        from LDMX.SimCore import kaon_physics
+        self.kaon_parameters = kaon_physics.KaonPhysics()
+
     def setDetector(self, det_name , include_scoring_planes = False ) :
         """Set the detector description with the option to include the scoring planes
 

--- a/src/SimCore/Event/SimParticle.cxx
+++ b/src/SimCore/Event/SimParticle.cxx
@@ -32,6 +32,9 @@ ClassImp(ldmx::SimParticle)
     procMap["GammaToMuPair"] = ProcessType::GammaToMuPair;
     /// e- Z --> e- Z A'
     procMap["DarkBrem"] = ProcessType::eDarkBrem;
+
+    // Decay
+    procMap["Decay"] = ProcessType::Decay;
     return procMap;
   }
 

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -13,5 +13,27 @@ KaonPhysics::KaonPhysics(const G4String& name,
   kminus_lifetime_factor =
       parameters.getParameter<double>("kminus_lifetime_factor");
 }
+void KaonPhysics::setDecayProperties(
+    G4ParticleDefinition* kaon, const std::vector<double>& branching_ratios,
+    double lifetime_factor) const {
+  kaon->SetPDGLifeTime(kaon->GetPDGLifeTime() * lifetime_factor);
+  auto table{kaon->GetDecayTable()};
+  if (!table) {
+    EXCEPTION_RAISE("KaonPhysics", "Unable to get the decay table from " +
+                                       kaon->GetParticleName());
+  }
+  (*table)[KaonDecayChannel::mu_nu]->SetBR(
+      branching_ratios[KaonDecayChannel::mu_nu]);
+  (*table)[KaonDecayChannel::pi_pi0]->SetBR(
+      branching_ratios[KaonDecayChannel::pi_pi0]);
+  (*table)[KaonDecayChannel::pi_pi_pi]->SetBR(
+      branching_ratios[KaonDecayChannel::pi_pi_pi]);
+  (*table)[KaonDecayChannel::pi_pi0_pi0]->SetBR(
+      branching_ratios[KaonDecayChannel::pi_pi0_pi0]);
+  (*table)[KaonDecayChannel::pi0_e_nu]->SetBR(
+      branching_ratios[KaonDecayChannel::pi0_e_nu]);
+  (*table)[KaonDecayChannel::pi0_mu_nu]->SetBR(
+      branching_ratios[KaonDecayChannel::pi0_mu_nu]);
+}
 
 }  // namespace simcore

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -1,5 +1,17 @@
 #include "SimCore/KaonPhysics.h"
 
 namespace simcore {
+KaonPhysics::KaonPhysics(const G4String& name,
+                         const framework::config::Parameters& parameters)
+    : G4VPhysicsConstructor(name) {
+  kplus_branching_ratios =
+      parameters.getParameter<std::vector<double>>("kplus_branching_ratios");
+  kminus_branching_ratios =
+      parameters.getParameter<std::vector<double>>("kminus_branching_ratios");
+  kplus_lifetime_factor =
+      parameters.getParameter<double>("kplus_lifetime_factor");
+  kminus_lifetime_factor =
+      parameters.getParameter<double>("kminus_lifetime_factor");
+}
 
 }  // namespace simcore

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -1,0 +1,5 @@
+#include "SimCore/KaonPhysics.h"
+
+namespace simcore {
+
+}  // namespace simcore

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -8,10 +8,16 @@ KaonPhysics::KaonPhysics(const G4String& name,
       parameters.getParameter<std::vector<double>>("kplus_branching_ratios");
   kminus_branching_ratios =
       parameters.getParameter<std::vector<double>>("kminus_branching_ratios");
+  k0l_branching_ratios =
+      parameters.getParameter<std::vector<double>>("k0l_branching_ratios");
+  k0s_branching_ratios =
+      parameters.getParameter<std::vector<double>>("k0s_branching_ratios");
   kplus_lifetime_factor =
       parameters.getParameter<double>("kplus_lifetime_factor");
   kminus_lifetime_factor =
       parameters.getParameter<double>("kminus_lifetime_factor");
+  k0l_lifetime_factor = parameters.getParameter<double>("k0l_lifetime_factor");
+  k0s_lifetime_factor = parameters.getParameter<double>("k0s_lifetime_factor");
 }
 void KaonPhysics::setDecayProperties(
     G4ParticleDefinition* kaon, const std::vector<double>& branching_ratios,
@@ -22,24 +28,46 @@ void KaonPhysics::setDecayProperties(
     EXCEPTION_RAISE("KaonPhysics", "Unable to get the decay table from " +
                                        kaon->GetParticleName());
   }
-  (*table)[KaonDecayChannel::mu_nu]->SetBR(
-      branching_ratios[KaonDecayChannel::mu_nu]);
-  (*table)[KaonDecayChannel::pi_pi0]->SetBR(
-      branching_ratios[KaonDecayChannel::pi_pi0]);
-  (*table)[KaonDecayChannel::pi_pi_pi]->SetBR(
-      branching_ratios[KaonDecayChannel::pi_pi_pi]);
-  (*table)[KaonDecayChannel::pi_pi0_pi0]->SetBR(
-      branching_ratios[KaonDecayChannel::pi_pi0_pi0]);
-  (*table)[KaonDecayChannel::pi0_e_nu]->SetBR(
-      branching_ratios[KaonDecayChannel::pi0_e_nu]);
-  (*table)[KaonDecayChannel::pi0_mu_nu]->SetBR(
-      branching_ratios[KaonDecayChannel::pi0_mu_nu]);
+  if (kaon == G4KaonZeroLong::Definition()) {
+    (*table)[KaonZeroLongDecayChannel::pi0_pi0_pi0]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pi0_pi0_pi0]);
+    (*table)[KaonZeroLongDecayChannel::pi0_pip_pim]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pi0_pip_pim]);
+    (*table)[KaonZeroLongDecayChannel::pip_e_nu]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pip_e_nu]);
+    (*table)[KaonZeroLongDecayChannel::pim_e_nu]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pim_e_nu]);
+    (*table)[KaonZeroLongDecayChannel::pim_mu_nu]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pim_mu_nu]);
+    (*table)[KaonZeroLongDecayChannel::pip_mu_nu]->SetBR(
+        branching_ratios[KaonZeroLongDecayChannel::pip_mu_nu]);
+  } else if (kaon == G4KaonZeroShort::Definition()) {
+    (*table)[KaonZeroShortDecayChannel::pip_pim]->SetBR(
+        branching_ratios[KaonZeroShortDecayChannel::pip_pim]);
+    (*table)[KaonZeroShortDecayChannel::pi0_pi0]->SetBR(
+        branching_ratios[KaonZeroShortDecayChannel::pi0_pi0]);
+  } else {
+    (*table)[ChargedKaonDecayChannel::mu_nu]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::mu_nu]);
+    (*table)[ChargedKaonDecayChannel::pi_pi0]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::pi_pi0]);
+    (*table)[ChargedKaonDecayChannel::pi_pi_pi]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::pi_pi_pi]);
+    (*table)[ChargedKaonDecayChannel::pi_pi0_pi0]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::pi_pi0_pi0]);
+    (*table)[ChargedKaonDecayChannel::pi0_e_nu]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::pi0_e_nu]);
+    (*table)[ChargedKaonDecayChannel::pi0_mu_nu]->SetBR(
+        branching_ratios[ChargedKaonDecayChannel::pi0_mu_nu]);
+  }
 }
 void KaonPhysics::ConstructParticle() {
   auto kaonPlus{G4KaonPlus::Definition()};
   auto kaonMinus{G4KaonMinus::Definition()};
+  auto kaonLong{G4KaonZeroLong::Definition()};
+  auto kaonShort{G4KaonZeroShort::Definition()};
 
-  if (!kaonPlus || !kaonMinus) {
+  if (!kaonPlus || !kaonMinus || !kaonLong || !kaonShort) {
     EXCEPTION_RAISE("KaonPhysics",
                     "Unable to get the charged kaon particle definitions, "
                     "something is very wrong with the configuration.");
@@ -47,6 +75,8 @@ void KaonPhysics::ConstructParticle() {
   setDecayProperties(kaonPlus, kplus_branching_ratios, kplus_lifetime_factor);
   setDecayProperties(kaonMinus, kminus_branching_ratios,
                      kminus_lifetime_factor);
+  setDecayProperties(kaonLong, k0l_branching_ratios, k0l_lifetime_factor);
+  setDecayProperties(kaonShort, k0s_branching_ratios, k0s_lifetime_factor);
 }
 
 }  // namespace simcore

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -35,5 +35,18 @@ void KaonPhysics::setDecayProperties(
   (*table)[KaonDecayChannel::pi0_mu_nu]->SetBR(
       branching_ratios[KaonDecayChannel::pi0_mu_nu]);
 }
+void KaonPhysics::ConstructParticle() {
+  auto kaonPlus{G4KaonPlus::Definition()};
+  auto kaonMinus{G4KaonMinus::Definition()};
+
+  if (!kaonPlus || !kaonMinus) {
+    EXCEPTION_RAISE("KaonPhysics",
+                    "Unable to get the charged kaon particle definitions, "
+                    "something is very wrong with the configuration.");
+  }
+  setDecayProperties(kaonPlus, kplus_branching_ratios, kplus_lifetime_factor);
+  setDecayProperties(kaonMinus, kminus_branching_ratios,
+                     kminus_lifetime_factor);
+}
 
 }  // namespace simcore

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -62,6 +62,7 @@ void RunManager::setupPhysics() {
   pList->RegisterPhysics(new GammaPhysics{"GammaPhysics", parameters_});
   pList->RegisterPhysics(new APrimePhysics(
       parameters_.getParameter<framework::config::Parameters>("dark_brem")));
+  pList->RegisterPhysics(new KaonPhysics("KaonPhysics", parameters_.getParameter<framework::config::Parameters>("kaon_parameters")));
 
   auto biasing_operators{
       parameters_.getParameter<std::vector<framework::config::Parameters>>(

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -62,7 +62,9 @@ void RunManager::setupPhysics() {
   pList->RegisterPhysics(new GammaPhysics{"GammaPhysics", parameters_});
   pList->RegisterPhysics(new APrimePhysics(
       parameters_.getParameter<framework::config::Parameters>("dark_brem")));
-  pList->RegisterPhysics(new KaonPhysics("KaonPhysics", parameters_.getParameter<framework::config::Parameters>("kaon_parameters")));
+  pList->RegisterPhysics(new KaonPhysics(
+      "KaonPhysics", parameters_.getParameter<framework::config::Parameters>(
+                         "kaon_parameters")));
 
   auto biasing_operators{
       parameters_.getParameter<std::vector<framework::config::Parameters>>(

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -35,8 +35,8 @@
 namespace simcore {
 
 RunManager::RunManager(framework::config::Parameters& parameters,
-                       ConditionsInterface& ci)
-    : conditionsIntf_(ci) {
+                       ConditionsInterface& )
+{
   parameters_ = parameters;
 
   // Set whether the ROOT primary generator should use the persisted seed.

--- a/src/SimCore/RunManager.cxx
+++ b/src/SimCore/RunManager.cxx
@@ -35,8 +35,7 @@
 namespace simcore {
 
 RunManager::RunManager(framework::config::Parameters& parameters,
-                       ConditionsInterface& )
-{
+                       ConditionsInterface&) {
   parameters_ = parameters;
 
   // Set whether the ROOT primary generator should use the persisted seed.


### PR DESCRIPTION
This PR adds the ability to change the kaon physics at runtime by modifying the properties of the `G4KaonMinus` and `G4KaonPlus` particle definitions rather than doing it manually in the Geant4 sources. This should significantly simplify the study of challenging kaon backgrounds, especially together with techniques like https://ldmx-software.github.io/Alternative-Photo-Nuclear-Models.html 

I also add "Decay" as one of the processes registered in the ProcessMap so that you can tell that a daughter particle came from a decay. 

To verify that this works, I used a configuration like the following and some checks in the SimObjects DQM code to check basic things like "if I force only one decay type, I always get daughter particles of that type" etc
``` 
from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('test')

p.maxTriesPerEvent = 1

from LDMX.SimCore import generators as gen
from LDMX.SimCore import simulator
from LDMX.SimCore import kaon_physics
mySim = simulator.simulator('kaon_test')

gun = gen.gun('kaon_gun')
gun.particle='kaon+'
gun.position = [0.,0.,0.]
gun.direction = [0.,0.,1.]
gun.energy = 0.
mySim.setDetector('ldmx-det-v14-8gev')
mySim.beamSpotSmear = [20.,80.,0.]
mySim.description = 'ECal PN Test Simulation'
mySim.generators = [gun]
mySim.kaon_parameters = kaon_physics.KaonPhysics.upKaons()
mySim.kaon_parameters.kplus_lifetime_factor = 1/10000000000000000.
mySim.kaon_parameters.kminus_lifetime_factor = 1/10000000000000000.
mySim.kaon_parameters.kplus_branching_ratios = [0., 1., 0., 0., 0., 0.]
p.sequence = [ mySim ]

##################################################################
# Below should be the same for all sim scenarios

import os
import sys

if 'LDMX_NUM_EVENTS' in os.environ:
    p.maxEvents = int(os.environ['LDMX_NUM_EVENTS'])
else:
    p.maxEvents = int(sys.argv[1])
if 'LDMX_RUN_NUMBER' in os.environ:
    p.run = int(os.environ['LDMX_RUN_NUMBER'])
else:
    p.run = 1

output_base = 'kaon_test'
if len(sys.argv) > 2:
    output_base = sys.argv[2]


p.histogramFile = f'{output_base}_hist.root'
p.outputFiles = [f'{output_base}_events.root']

import LDMX.Ecal.EcalGeometry
import LDMX.Hcal.HcalGeometry


from LDMX.DQM import dqm

p.sequence.extend([
    dqm.SimObjects()
])
```

This resolves #106 and part of #107 