### PR TITLE
106 see if kaon properties can be configured at runtime patch

### DIFF
--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -40,22 +40,25 @@ class KaonPhysics : public G4VPhysicsConstructor {
    * K^+ -> \mu^+ + \nu_\mu
    * K^+ -> \pi^+ + \pi^0
    * K^+ -> \pi^+ + \pi^- + \pi^+
-   * K^+ -> \pi^+ + \pi^0 + \pi^0
    * K^+ -> \pi^0 + e^+ + \nu_e
    * K^+ -> \pi^0 + \mu^+ + \nu_\mu
+   * K^+ -> \pi^+ + \pi^0 + \pi^0
    *
    * And vice versa for K^-.
    * The indices here correspond to the position of the branching ratio for
    * that process in the corresponding parameter as well as the position in
    * the decay table.
+   *
+   * @note: The order in the the decay table is sorted by the branching ratios
+   * of the default physics settings!
    */
   enum ChargedKaonDecayChannel {
     mu_nu = 0,
     pi_pi0 = 1,
     pi_pi_pi = 2,
-    pi_pi0_pi0 = 3,
-    pi0_e_nu = 4,
-    pi0_mu_nu = 5
+    pi0_e_nu = 3,
+    pi0_mu_nu = 4,
+    pi_pi0_pi0 = 5,
   };
   /**
    *
@@ -64,26 +67,29 @@ class KaonPhysics : public G4VPhysicsConstructor {
    *
    * The processes are
    *
-   * K^0_L -> \pi^0 + \pi^0 + \pi^0
-   * K^0_L -> \pi^0 + \pi^+ + \pi^-
    * K^0_L -> \pi^- + e^+ + \nu_e
    * K^0_L -> \pi^+ + e^- + \nu_e
+   * K^0_L -> \pi^0 + \pi^0 + \pi^0
    * K^0_L -> \pi^- + \mu^+ + \nu_\mu
    * K^0_L -> \pi^+ + \mu^- + \nu_\mu
+   * K^0_L -> \pi^0 + \pi^+ + \pi^-
    *
    * and
    *
    * K^0_S -> \pi^+ + \pi^-
    * K^0_S -> \pi^0 + \pi^0
    *
+   * @note: The order in the the decay table is sorted by the branching ratios
+   * of the default physics settings!
+   *
    **/
   enum KaonZeroLongDecayChannel {
-    pi0_pi0_pi0 = 0,
-    pi0_pip_pim = 1,
-    pip_e_nu = 2,
-    pim_e_nu = 3,
-    pim_mu_nu = 4,
-    pip_mu_nu = 5,
+    pim_e_nu = 0,
+    pip_e_nu = 1,
+    pi0_pi0_pi0 = 2,
+    pim_mu_nu = 3,
+    pip_mu_nu = 4,
+    pi0_pip_pim = 5,
   };
   enum KaonZeroShortDecayChannel {
     pip_pim = 0,
@@ -107,6 +113,7 @@ class KaonPhysics : public G4VPhysicsConstructor {
   // If > 0, dump details about what was changed
   // If > 1, dump details about the initial branching ratios
   int verbosity;
+
  public:
   KaonPhysics(const G4String& name,
               const framework::config::Parameters& parameters);

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -104,6 +104,9 @@ class KaonPhysics : public G4VPhysicsConstructor {
   std::vector<double> k0l_branching_ratios;
   std::vector<double> k0s_branching_ratios;
 
+  // If > 0, dump details about what was changed
+  // If > 1, dump details about the initial branching ratios
+  int verbosity;
  public:
   KaonPhysics(const G4String& name,
               const framework::config::Parameters& parameters);

--- a/include/SimCore/KaonPhysics.h
+++ b/include/SimCore/KaonPhysics.h
@@ -9,6 +9,8 @@
 #include <G4ParticleDefinition.hh>
 #include <G4VDecayChannel.hh>
 #include <G4VPhysicsConstructor.hh>
+#include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <vector>
 
@@ -126,6 +128,8 @@ class KaonPhysics : public G4VPhysicsConstructor {
    */
 
   void ConstructParticle() override;
+
+  void DumpDecayDetails(const G4ParticleDefinition* kaon) const;
 
   /**
    * Construct processes

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -55,25 +55,25 @@ class KaonPhysics():
             0.6355,  # K^+ -> mu^+ + nu_mu
             0.2066,  # K^+ -> pi^+ + pi^0
             0.0559,  # K^+ -> pi^+ + pi^- + pi^+
-            0.01761, # K^+ -> pi^+ + pi^0 + pi^0
             0.0507,  # K^+ -> pi^0 + e^+ + nu_e
             0.0335,  # K^+ -> pi^0 + mu^+ + nu_mu
+            0.01761, # K^+ -> pi^+ + pi^0 + pi^0
         ]
         self.kminus_branching_ratios = [
             0.6355,  # K^- -> mu^- + anti_nu_mu
             0.2066,  # K^- -> pi^- + pi^0
             0.0559,  # K^- -> pi^- + pi^+ + pi^-
-            0.01761, # K-+ -> pi^- + pi^0 + pi^0
             0.0507,  # K-+ -> pi^0 + e^- + anti_nu_e
             0.0335,  # K-+ -> pi^0 + mu^- + anti_nu_mu
+            0.01761, # K-+ -> pi^- + pi^0 + pi^0
         ]
         self.k0l_branching_ratios = [
-            0.1952, # K^0_L -> pi^0 + pi^0 + pi^0
-            0.1254, # K^0_L -> pi^0 + pi^+ + pi^-
             0.2027, # K^0_L -> pi^- + e^+ + nu_e
             0.2027, # K^0_L -> pi^+ + e^- + anti_nu_e
+            0.1952, # K^0_L -> pi^0 + pi^0 + pi^0
             0.1352, # K^0_L -> pi^- + mu^+ + nu_mu
             0.1352, # K^0_L -> pi^+ + mu^- + anti_nu_mu
+            0.1254, # K^0_L -> pi^0 + pi^+ + pi^-
         ]
         self.k0s_branching_ratios = [
             0.6920, # K^0_S -> pi^+ + pi^-
@@ -101,19 +101,19 @@ class KaonPhysics():
         kaon_physics = KaonPhysics()
         kaon_physics.kplus_branching_ratios = [
             0.8831,  # K^+ -> mu^+ + nu_mu
-            0.,  # K^+ -> pi^+ + pi^0
-            0.,  # K^+ -> pi^+ + pi^- + pi^+
-            0., # K^+ -> pi^+ + pi^0 + pi^0
+            0.,      # K^+ -> pi^+ + pi^0
+            0.,      # K^+ -> pi^+ + pi^- + pi^+
             0.0704,  # K^+ -> pi^0 + e^+ + nu_e
             0.0465,  # K^+ -> pi^0 + mu^+ + nu_mu
+            0.,      # K^+ -> pi^+ + pi^0 + pi^0
         ]
         kaon_physics.kminus_branching_ratios = [
             0.8831,  # K^- -> mu^- + anti_nu_mu
-            0.,  # K^- -> pi^- + pi^0
-            0.,  # K^- -> pi^- + pi^+ + pi^-
-            0., # K-+ -> pi^- + pi^0 + pi^0
-            0.0704,  # K-+ -> pi^0 + e^- + anti_nu_e
-            0.0464,  # K-+ -> pi^0 + mu^- + anti_nu_mu
+            0.,      # K^- -> pi^- + pi^0
+            0.,      # K^- -> pi^- + pi^+ + pi^-
+            0.0704,  # K^- -> pi^0 + e^- + anti_nu_e
+            0.0464,  # K^- -> pi^0 + mu^- + anti_nu_mu
+            0.,      # K^- -> pi^- + pi^0 + pi^0
         ]
         kaon_physics.kplus_lifetime_factor = 1/50.
         kaon_physics.kminus_lifetime_factor = 1/50.

--- a/python/kaon_physics.py
+++ b/python/kaon_physics.py
@@ -43,6 +43,12 @@ class KaonPhysics():
         Multiplicative factor to scale the lifetime of kaons by. Default is to
         scale by 1 (no scaling)
 
+    verbosity : int
+
+        If > 0: Dump details about the decay after the update
+        If > 1: Also dump details about the decay before the update to show the
+        difference
+
     """
     def __init__(self):
         self.kplus_branching_ratios = [
@@ -78,6 +84,8 @@ class KaonPhysics():
         self.k0l_lifetime_factor = 1.
         self.k0s_lifetime_factor = 1.
 
+        self.verbosity=0
+
 
     def upKaons():
         """Returns a configuration of the kaon physics corresponding
@@ -109,6 +117,7 @@ class KaonPhysics():
         ]
         kaon_physics.kplus_lifetime_factor = 1/50.
         kaon_physics.kminus_lifetime_factor = 1/50.
+        kaon_physics.verbosity = 2
         return kaon_physics
 
     def __setattr__(self, key, value):

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -23,7 +23,6 @@ KaonPhysics::KaonPhysics(const G4String& name,
 void KaonPhysics::setDecayProperties(
     G4ParticleDefinition* kaon, const std::vector<double>& branching_ratios,
     double lifetime_factor) const {
-  kaon->SetPDGLifeTime(kaon->GetPDGLifeTime() * lifetime_factor);
   auto table{kaon->GetDecayTable()};
   if (!table) {
     EXCEPTION_RAISE("KaonPhysics", "Unable to get the decay table from " +
@@ -34,6 +33,7 @@ void KaonPhysics::setDecayProperties(
               << std::endl;
     DumpDecayDetails(kaon);
   }
+  kaon->SetPDGLifeTime(kaon->GetPDGLifeTime() * lifetime_factor);
   if (kaon == G4KaonZeroLong::Definition()) {
     (*table)[KaonZeroLongDecayChannel::pi0_pi0_pi0]->SetBR(
         branching_ratios[KaonZeroLongDecayChannel::pi0_pi0_pi0]);
@@ -112,4 +112,5 @@ void KaonPhysics::DumpDecayDetails(const G4ParticleDefinition* kaon) const {
               << std::endl;
   }
 }
+
 }  // namespace simcore

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -18,6 +18,7 @@ KaonPhysics::KaonPhysics(const G4String& name,
       parameters.getParameter<double>("kminus_lifetime_factor");
   k0l_lifetime_factor = parameters.getParameter<double>("k0l_lifetime_factor");
   k0s_lifetime_factor = parameters.getParameter<double>("k0s_lifetime_factor");
+  verbosity = parameters.getParameter<int>("verbosity");
 }
 void KaonPhysics::setDecayProperties(
     G4ParticleDefinition* kaon, const std::vector<double>& branching_ratios,
@@ -27,6 +28,11 @@ void KaonPhysics::setDecayProperties(
   if (!table) {
     EXCEPTION_RAISE("KaonPhysics", "Unable to get the decay table from " +
                                        kaon->GetParticleName());
+  }
+  if (verbosity > 1) {
+    std::cout << "Decay details after setting branching ratios and lifetimes"
+              << std::endl;
+    DumpDecayDetails(kaon);
   }
   if (kaon == G4KaonZeroLong::Definition()) {
     (*table)[KaonZeroLongDecayChannel::pi0_pi0_pi0]->SetBR(
@@ -59,6 +65,11 @@ void KaonPhysics::setDecayProperties(
         branching_ratios[ChargedKaonDecayChannel::pi0_e_nu]);
     (*table)[ChargedKaonDecayChannel::pi0_mu_nu]->SetBR(
         branching_ratios[ChargedKaonDecayChannel::pi0_mu_nu]);
+  }
+  if (verbosity > 0) {
+    std::cout << "Decay details after setting branching ratios and lifetimes"
+              << std::endl;
+    DumpDecayDetails(kaon);
   }
 }
 void KaonPhysics::ConstructParticle() {

--- a/src/SimCore/KaonPhysics.cxx
+++ b/src/SimCore/KaonPhysics.cxx
@@ -79,4 +79,26 @@ void KaonPhysics::ConstructParticle() {
   setDecayProperties(kaonShort, k0s_branching_ratios, k0s_lifetime_factor);
 }
 
+void KaonPhysics::DumpDecayDetails(const G4ParticleDefinition* kaon) const {
+  std::cout << "Decay table details for " << kaon->GetParticleName()
+            << std::endl
+            << std::scientific << std::setprecision(15);
+  std::cout << "PDG Lifetime " << kaon->GetPDGLifeTime() << std::endl;
+  const auto table{kaon->GetDecayTable()};
+  const int entries{table->entries()};
+  for (auto i{0}; i < entries; ++i) {
+    const auto channel{(*table)[i]};
+    std::cout << "Channel " << i << " Kinematics type "
+              << channel->GetKinematicsName() << " with BR " << channel->GetBR()
+              << std::endl;
+    std::cout << kaon->GetParticleName() << " -> ";
+    const auto daughters{channel->GetNumberOfDaughters()};
+    for (auto j{0}; j < daughters - 1; ++j) {
+      std::cout << channel->GetDaughter(j)->GetParticleName() << " + ";
+    }
+    // Special formatting for last one :)
+    std::cout << channel->GetDaughter(daughters - 1)->GetParticleName()
+              << std::endl;
+  }
+}
 }  // namespace simcore


### PR DESCRIPTION
This patches a bug introduced in #108 where the ordering of the kaon branching ratios was incorrect