### PR TITLE
added method for tagging recoil electrons for nonfiducial filter

### DIFF
--- a/include/SimCore/UserEventInformation.h
+++ b/include/SimCore/UserEventInformation.h
@@ -118,6 +118,7 @@ class UserEventInformation : public G4VUserEventInformation {
   bool wasLastStepEN() const { return last_step_en_; }
 
  private:
+
   /// Total number of brem candidates in the event
   int bremCandidateCount_{0};
 

--- a/include/SimCore/UserEventInformation.h
+++ b/include/SimCore/UserEventInformation.h
@@ -118,7 +118,6 @@ class UserEventInformation : public G4VUserEventInformation {
   bool wasLastStepEN() const { return last_step_en_; }
 
  private:
-
   /// Total number of brem candidates in the event
   int bremCandidateCount_{0};
 

--- a/include/SimCore/UserTrackInformation.h
+++ b/include/SimCore/UserTrackInformation.h
@@ -5,7 +5,6 @@
 #include "G4Track.hh"
 #include "G4VUserTrackInformation.hh"
 
-
 namespace simcore {
 
 /**
@@ -84,7 +83,7 @@ class UserTrackInformation : public G4VUserTrackInformation {
     isBremCandidate_ = isBremCandidate;
   }
 
-/**
+  /**
    * Check whether this track is a recoil electron.
    *
    * @return true if this track is a recoil electron, false otherwise.
@@ -149,7 +148,7 @@ class UserTrackInformation : public G4VUserTrackInformation {
   /// Flag indicating whether this track is a brem candidate
   bool isBremCandidate_{false};
 
-    /// Flag indicating whether this track is a recoil electron
+  /// Flag indicating whether this track is a recoil electron
   bool isRecoilElectron_{false};
 
   /**

--- a/include/SimCore/UserTrackInformation.h
+++ b/include/SimCore/UserTrackInformation.h
@@ -5,6 +5,7 @@
 #include "G4Track.hh"
 #include "G4VUserTrackInformation.hh"
 
+
 namespace simcore {
 
 /**
@@ -83,6 +84,23 @@ class UserTrackInformation : public G4VUserTrackInformation {
     isBremCandidate_ = isBremCandidate;
   }
 
+/**
+   * Check whether this track is a recoil electron.
+   *
+   * @return true if this track is a recoil electron, false otherwise.
+   */
+  bool isRecoilElectron() const { return isRecoilElectron_; }
+
+  /**
+   * Tag this track as a recoil electron by the biasing filters.
+   *
+   * @param[in] isRecoilElectron flag indicating whether this track is
+   *      a recoil electron or not.
+   */
+  void tagRecoilElectron(bool isRecoilElectron = true) {
+    isRecoilElectron_ = isRecoilElectron;
+  }
+
   /**
    * Check whether this track is a photon that has undergone a
    * photo-nuclear reaction.
@@ -130,6 +148,9 @@ class UserTrackInformation : public G4VUserTrackInformation {
 
   /// Flag indicating whether this track is a brem candidate
   bool isBremCandidate_{false};
+
+    /// Flag indicating whether this track is a recoil electron
+  bool isRecoilElectron_{false};
 
   /**
    * Flag indicating whether this track has undergone a photo-nuclear


### PR DESCRIPTION
In the manner of cleaning stale branches, I found this from UCSB and rebased it to trunk. There is no issue to connect to IIUC